### PR TITLE
build: pin pnpm version for reproducible builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,8 +17,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -11,5 +11,6 @@
   },
   "keywords": [],
   "author": "",
-  "license": "MIT"
+  "license": "MIT",
+  "packageManager": "pnpm@10.34.1"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,5 +5,8 @@ packages:
 
 ignoredBuiltDependencies:
   - '@prisma/engines'
+  - cpu-features
   - esbuild
   - prisma
+  - protobufjs
+  - ssh2


### PR DESCRIPTION
## Summary
Fixes the deploy pipeline failing at build-and-push.

Root cause: pnpm was unpinned, so the Dockerfiles' corepack pulled the latest pnpm (11.x) while CI and local used pnpm 10. pnpm 11's stricter defaults (minimumReleaseAge and a hard error on ignored build scripts) rejected the frozen install that pnpm 10 accepts.

- Pin packageManager to pnpm@10.34.1 so Docker, CI, and local all match.
- Read the pinned version in CI instead of hardcoding pnpm 10 in the workflow.
- Acknowledge the Testcontainers native build deps in ignoredBuiltDependencies.

Verified by building Dockerfile.server locally end to end.