### PR TITLE
ci: update GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -42,10 +42,10 @@ jobs:
       packages: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
## Summary
GitHub is deprecating the Node 20 runtime for actions (forced to Node 24 on 2026-06-16, removed 2026-09-16). Bumps the four affected actions to their current Node 24 majors:

- actions/checkout v4 -> v6
- actions/setup-node v4 -> v6
- pnpm/action-setup v4 -> v6 (still auto-detects pnpm from packageManager)
- docker/login-action v3 -> v4

The test job runs on this PR, so the new versions are validated before merge.