### PR TITLE
feat: Redis-backed sessions with refresh-token rotation and reuse detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Relates is a high-performance, full-stack social media platform inspired by mode
 - **Optimistic UI Interaction**: Zero-latency feedback for Likes and interactions via React Query.
 - **Full Post Lifecycle**: Create, Edit, and Soft-Delete capabilities for posts and nested replies.
 - **Advanced Profile Management**: Live profile editing (Name, Bio, Avatar URL) with instant cross-app synchronization.
-- **Secure Authentication**: JWT-based auth with automatic token refresh linked to live database state.
+- **Secure Authentication**: JWT auth with refresh-token rotation and reuse detection, backed by a Redis session store, with log-out-everywhere support.
 - **Responsive Design**: Polished mobile and desktop layouts featuring a smart navigation system and unified "Menu" button.
 
 ## Client Architecture
@@ -57,6 +57,7 @@ A scalable Express backend focused on data integrity and performance.
 - **Express** & **TypeScript**
 - **Prisma ORM** for type-safe database operations
 - **PostgreSQL** for relational data storage
+- **Redis** for session storage and refresh-token rotation
 - **Zod** for end-to-end type safety and validation
 - **Argon2** for industry-standard password hashing
 
@@ -65,7 +66,7 @@ A scalable Express backend focused on data integrity and performance.
 - **Soft-Delete System**: Database-safe post removal ensuring data integrity and relationship stability.
 - **Blended Feed Logic**: Complex Prisma queries for fetching network-relevant content.
 - **Type-Safe Search**: Case-insensitive partial matching for users and posts.
-- **Live Token Refresh**: Refresh mechanism that pulls latest profile data from DB to prevent stale client state.
+- **Rotating Sessions**: Refresh tokens rotate on every use with reuse detection (a replayed token revokes the session); per-request auth validates the signed token without a database lookup.
 - **Modular Controllers**: Clean separation of concerns for Auth, Post, User, and Search logic.
 
 ## Packages

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Relates
 
-Relates is a high-performance, full-stack social media platform inspired by modern threads-style interaction. Built with `React`, `TypeScript`, `Vite`, `Express`, and `PostgreSQL`, it features a sophisticated UI, real-time optimistic updates, and a robust search engine.
+Relates is a high-performance, full-stack social media platform inspired by modern threads-style interaction. Built with `React`, `TypeScript`, `Vite`, `Express`, `PostgreSQL`, and `Redis`, it features a sophisticated UI, real-time optimistic updates, and a robust search engine.
 
 ## Table of Contents
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -10,3 +10,6 @@ services:
       - .env.local
     ports:
       - "5432:5432"
+  redis:
+    ports:
+      - "6379:6379"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,12 +17,29 @@ services:
       timeout: 5s
       retries: 5
 
+  redis:
+    image: redis:7-alpine
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - redis_data:/data
+    networks: [appnet]
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
   server:
     image: ghcr.io/lrdinsu/relates-server:latest
     env_file:
       - ./server/.prod.env
+    environment:
+      REDIS_URL: redis://redis:6379
     depends_on:
       db:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     networks: [appnet]
     restart: unless-stopped
@@ -53,3 +70,4 @@ networks:
 
 volumes:
   pg_data:
+  redis_data:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,6 +214,9 @@ importers:
       supertest:
         specifier: ^7.2.2
         version: 7.2.2
+      testcontainers:
+        specifier: ^12.0.1
+        version: 12.0.1
       tsdown:
         specifier: 0.21.0-beta.2
         version: 0.21.0-beta.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(typescript@6.0.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
+      ioredis:
+        specifier: ^5.11.1
+        version: 5.11.1
       jsonwebtoken:
         specifier: ^9.0.3
         version: 9.0.3
@@ -593,6 +596,9 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@ioredis/commands@1.10.0':
+    resolution: {integrity: sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -1761,6 +1767,10 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cluster-key-slot@1.1.1:
+    resolution: {integrity: sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==}
+    engines: {node: '>=0.10.0'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -2391,6 +2401,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  ioredis@5.11.1:
+    resolution: {integrity: sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==}
+    engines: {node: '>=12.22.0'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -3190,6 +3204,14 @@ packages:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -3387,6 +3409,9 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -4198,6 +4223,8 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@ioredis/commands@1.10.0': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -5334,6 +5361,8 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cluster-key-slot@1.1.1: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -6067,6 +6096,18 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.4
       side-channel: 1.1.0
+
+  ioredis@5.11.1:
+    dependencies:
+      '@ioredis/commands': 1.10.0
+      cluster-key-slot: 1.1.1
+      debug: 4.4.3
+      denque: 2.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   ipaddr.js@1.9.1: {}
 
@@ -6833,6 +6874,12 @@ snapshots:
 
   readdirp@5.0.0: {}
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.9
@@ -7113,6 +7160,8 @@ snapshots:
       nan: 2.27.0
 
   stackback@0.0.2: {}
+
+  standard-as-callback@2.1.0: {}
 
   statuses@2.0.2: {}
 

--- a/server/package.json
+++ b/server/package.json
@@ -22,6 +22,7 @@
     "cookie-parser": "^1.4.7",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
+    "ioredis": "^5.11.1",
     "jsonwebtoken": "^9.0.3",
     "pg": "^8.21.0",
     "prisma": "^7.8.0",

--- a/server/package.json
+++ b/server/package.json
@@ -42,6 +42,7 @@
     "eslint": "^9.39.4",
     "globals": "^15.15.0",
     "supertest": "^7.2.2",
+    "testcontainers": "^12.0.1",
     "tsdown": "0.21.0-beta.2",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3",

--- a/server/src/controllers/authController.ts
+++ b/server/src/controllers/authController.ts
@@ -7,10 +7,20 @@ import argon2 from '@node-rs/argon2';
 import { prisma } from '../db';
 import { checkPassword } from '../utils/checkPassword.js';
 import {
+  clearRefreshCookie,
   generateAccessToken,
   generateTokenAndSetCookie,
+  setRefreshCookie,
+  signRefreshToken,
 } from '../utils/generateTokenAndSetCookie.js';
 import { jwtVerify } from '../utils/jwtVerify.js';
+import {
+  deleteAllSessions,
+  deleteSession,
+  getSessionJti,
+  newId,
+  storeSession,
+} from '../utils/session.js';
 
 export async function signupUser(req: Request, res: Response) {
   try {
@@ -48,7 +58,7 @@ export async function signupUser(req: Request, res: Response) {
       },
     });
 
-    generateTokenAndSetCookie(
+    await generateTokenAndSetCookie(
       newUser.id,
       res,
       newUser.username,
@@ -91,7 +101,7 @@ export async function loginUser(req: Request, res: Response) {
     }
 
     // generate token and set cookie
-    generateTokenAndSetCookie(user.id, res, user.username, user.profilePic);
+    await generateTokenAndSetCookie(user.id, res, user.username, user.profilePic);
     res.status(200).json({
       accessToken: generateAccessToken(user.id),
       userId: user.id,
@@ -104,9 +114,28 @@ export async function loginUser(req: Request, res: Response) {
   }
 }
 
-export function logoutUser(_req: Request, res: Response) {
+export async function logoutUser(req: Request, res: Response) {
   try {
-    res.clearCookie('refreshToken');
+    const token =
+      typeof req.cookies.refreshToken === 'string'
+        ? req.cookies.refreshToken
+        : undefined;
+
+    if (token) {
+      try {
+        const { userId, sid } = await jwtVerify(
+          token,
+          process.env.REFRESH_TOKEN_SECRET!,
+        );
+        if (sid) {
+          await deleteSession(userId, sid);
+        }
+      } catch {
+        // An invalid/expired token just means there's nothing to revoke.
+      }
+    }
+
+    clearRefreshCookie(res);
     res.status(204).send();
   } catch (error) {
     res.status(500).json({ message: 'Unknown error occurred!' });
@@ -114,10 +143,23 @@ export function logoutUser(_req: Request, res: Response) {
   }
 }
 
-// Token refresh function
+// Logs the user out of every device by deleting all their sessions.
+export async function logoutAllSessions(req: Request, res: Response) {
+  try {
+    const userId = req.user!.id;
+    await deleteAllSessions(userId);
+    clearRefreshCookie(res);
+    res.status(204).send();
+  } catch (error) {
+    res.status(500).json({ message: 'Unknown error occurred!' });
+    console.error('Error in logoutAllSessions:', error);
+  }
+}
+
+// Rotates the refresh token and issues a new access token. Detects reuse of a
+// retired token (token theft) and revokes the session.
 export async function refreshAccessToken(req: Request, res: Response) {
   try {
-    // Get refresh token from cookies
     const token =
       typeof req.cookies.refreshToken === 'string'
         ? req.cookies.refreshToken
@@ -128,10 +170,38 @@ export async function refreshAccessToken(req: Request, res: Response) {
       return;
     }
 
-    const { userId } = await jwtVerify(
+    const { userId, sid, jti } = await jwtVerify(
       token,
       process.env.REFRESH_TOKEN_SECRET!,
     );
+
+    // Tokens issued before sessions existed can't be validated against the store.
+    if (!sid || !jti) {
+      res.status(401).json({ message: 'Please log in again' });
+      return;
+    }
+
+    let storedJti: string | null;
+    try {
+      storedJti = await getSessionJti(userId, sid);
+    } catch {
+      // Fail closed: if the session store is unreachable, reject the refresh.
+      res.status(401).json({ message: 'Please log in again' });
+      return;
+    }
+
+    if (!storedJti) {
+      // Session expired, logged out, or already revoked.
+      res.status(401).json({ message: 'Session expired, please log in' });
+      return;
+    }
+
+    if (storedJti !== jti) {
+      // A retired token was replayed: likely theft. Revoke the whole session.
+      await deleteSession(userId, sid);
+      res.status(401).json({ message: 'Session revoked, please log in' });
+      return;
+    }
 
     const user = await prisma.user.findUnique({
       where: { id: userId },
@@ -143,12 +213,19 @@ export async function refreshAccessToken(req: Request, res: Response) {
       return;
     }
 
-    const accessToken = generateAccessToken(userId);
-    res.status(200).json({ 
-      accessToken, 
-      userId: user.id, 
-      username: user.username, 
-      profilePic: user.profilePic 
+    // Rotate: issue a new token id, make it the only valid one, set the cookie.
+    const nextJti = newId();
+    await storeSession(userId, sid, nextJti);
+    setRefreshCookie(
+      res,
+      signRefreshToken(userId, user.username, user.profilePic, sid, nextJti),
+    );
+
+    res.status(200).json({
+      accessToken: generateAccessToken(userId),
+      userId: user.id,
+      username: user.username,
+      profilePic: user.profilePic,
     });
   } catch (error) {
     if (error instanceof jwt.TokenExpiredError) {

--- a/server/src/controllers/authController.ts
+++ b/server/src/controllers/authController.ts
@@ -17,8 +17,10 @@ import { jwtVerify } from '../utils/jwtVerify.js';
 import {
   deleteAllSessions,
   deleteSession,
+  getPreviousJti,
   getSessionJti,
   newId,
+  storePreviousJti,
   storeSession,
 } from '../utils/session.js';
 
@@ -196,11 +198,18 @@ export async function refreshAccessToken(req: Request, res: Response) {
       return;
     }
 
-    if (storedJti !== jti) {
-      // A retired token was replayed: likely theft. Revoke the whole session.
-      await deleteSession(userId, sid);
-      res.status(401).json({ message: 'Session revoked, please log in' });
-      return;
+    const isCurrent = storedJti === jti;
+
+    if (!isCurrent) {
+      // Not the current token. Accept the just-retired token within the grace
+      // window (concurrent refreshes from multiple tabs); anything older is a
+      // replay of a retired token, so treat it as theft and revoke.
+      const prevJti = await getPreviousJti(userId, sid);
+      if (prevJti !== jti) {
+        await deleteSession(userId, sid);
+        res.status(401).json({ message: 'Session revoked, please log in' });
+        return;
+      }
     }
 
     const user = await prisma.user.findUnique({
@@ -213,12 +222,19 @@ export async function refreshAccessToken(req: Request, res: Response) {
       return;
     }
 
-    // Rotate: issue a new token id, make it the only valid one, set the cookie.
-    const nextJti = newId();
-    await storeSession(userId, sid, nextJti);
+    // On the current token, rotate (new id, remember the retired one for the
+    // grace window). On a grace hit, re-issue the current token without
+    // rotating, so the racing request lands on the same token.
+    let cookieJti = storedJti;
+    if (isCurrent) {
+      cookieJti = newId();
+      await storeSession(userId, sid, cookieJti);
+      await storePreviousJti(userId, sid, jti);
+    }
+
     setRefreshCookie(
       res,
-      signRefreshToken(userId, user.username, user.profilePic, sid, nextJti),
+      signRefreshToken(userId, user.username, user.profilePic, sid, cookieJti),
     );
 
     res.status(200).json({

--- a/server/src/db/redis.ts
+++ b/server/src/db/redis.ts
@@ -1,0 +1,12 @@
+import { Redis } from 'ioredis';
+
+// Single shared client. ioredis reconnects in the background, and commands
+// fail after a few retries (rather than hanging) so the auth layer can decide
+// what to do when Redis is unavailable.
+export const redis = new Redis(process.env.REDIS_URL ?? 'redis://localhost:6379', {
+  maxRetriesPerRequest: 3,
+});
+
+redis.on('error', (err) => {
+  console.error('Redis connection error:', err.message);
+});

--- a/server/src/middlewares/protectRoute.ts
+++ b/server/src/middlewares/protectRoute.ts
@@ -1,7 +1,6 @@
 import { NextFunction, Request, Response } from 'express';
 import jwt from 'jsonwebtoken';
 
-import { prisma } from '../db';
 import { jwtVerify } from '../utils/jwtVerify.js';
 
 export async function protectRoute(
@@ -10,7 +9,6 @@ export async function protectRoute(
   next: NextFunction,
 ) {
   try {
-    // Get token from headers
     const token = req.headers.authorization?.split(' ')[1];
 
     if (!token) {
@@ -18,20 +16,10 @@ export async function protectRoute(
       return;
     }
 
-    // verify token
+    // Trust the short-lived signed access token; no per-request DB lookup.
+    // Account revocation happens at the refresh boundary via the session store.
     const { userId } = await jwtVerify(token, process.env.ACCESS_TOKEN_SECRET!);
-
-    const user = await prisma.user.findUnique({
-      where: { id: userId },
-    });
-
-    if (!user) {
-      res.status(404).json({ message: 'User not found' });
-      return;
-    }
-
-    // Attach user to req object
-    req.user = user;
+    req.user = { id: userId };
 
     next();
   } catch (error) {
@@ -61,18 +49,11 @@ export async function optionalProtectRoute(
     }
 
     const { userId } = await jwtVerify(token, process.env.ACCESS_TOKEN_SECRET!);
-
-    const user = await prisma.user.findUnique({
-      where: { id: userId },
-    });
-
-    if (user) {
-      req.user = user;
-    }
+    req.user = { id: userId };
 
     next();
   } catch {
-    // If token is invalid or expired, we just continue without user
+    // Invalid or expired token: continue as an anonymous request.
     next();
   }
 }

--- a/server/src/routes/authRoutes.ts
+++ b/server/src/routes/authRoutes.ts
@@ -2,10 +2,12 @@ import express, { Router } from 'express';
 
 import {
   loginUser,
+  logoutAllSessions,
   logoutUser,
   refreshAccessToken,
   signupUser,
 } from '../controllers/authController.js';
+import { protectRoute } from '../middlewares/protectRoute.js';
 
 export const authRouter: Router = express.Router();
 
@@ -13,4 +15,5 @@ export const authRouter: Router = express.Router();
 authRouter.post('/signup', signupUser);
 authRouter.post('/login', loginUser);
 authRouter.post('/logout', logoutUser);
+authRouter.post('/logout-all', protectRoute, logoutAllSessions);
 authRouter.get('/refresh-token', refreshAccessToken);

--- a/server/src/test/sessions.test.ts
+++ b/server/src/test/sessions.test.ts
@@ -1,0 +1,68 @@
+import request from 'supertest';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { app } from '../app';
+import { getRefreshCookie, signup } from './helpers';
+import { resetDatabase } from './setup/resetDb';
+
+const refresh = (cookie: string) =>
+  request(app).get('/api/v1/auth/refresh-token').set('Cookie', cookie);
+
+describe('refresh-token sessions', () => {
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  it('rotates the refresh token on each refresh', async () => {
+    const cookie1 = getRefreshCookie(await signup());
+
+    const res = await refresh(cookie1!);
+    expect(res.status).toBe(200);
+
+    const cookie2 = getRefreshCookie(res);
+    expect(cookie2).toBeDefined();
+    expect(cookie2).not.toBe(cookie1);
+  });
+
+  it('detects reuse of a retired token and revokes the session', async () => {
+    const cookie1 = getRefreshCookie(await signup());
+
+    const r1 = await refresh(cookie1!);
+    expect(r1.status).toBe(200);
+    const cookie2 = getRefreshCookie(r1);
+
+    // Replaying the old (rotated-out) token is treated as theft.
+    const reuse = await refresh(cookie1!);
+    expect(reuse.status).toBe(401);
+
+    // ...and the whole session is revoked, so the legit rotated token fails too.
+    const after = await refresh(cookie2!);
+    expect(after.status).toBe(401);
+  });
+
+  it('invalidates the session on logout', async () => {
+    const cookie = getRefreshCookie(await signup());
+
+    await request(app)
+      .post('/api/v1/auth/logout')
+      .set('Cookie', cookie!)
+      .expect(204);
+
+    const res = await refresh(cookie!);
+    expect(res.status).toBe(401);
+  });
+
+  it('logs out of every device with logout-all', async () => {
+    const signupRes = await signup();
+    const { accessToken } = signupRes.body;
+    const cookie = getRefreshCookie(signupRes);
+
+    await request(app)
+      .post('/api/v1/auth/logout-all')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(204);
+
+    const res = await refresh(cookie!);
+    expect(res.status).toBe(401);
+  });
+});

--- a/server/src/test/sessions.test.ts
+++ b/server/src/test/sessions.test.ts
@@ -24,19 +24,35 @@ describe('refresh-token sessions', () => {
     expect(cookie2).not.toBe(cookie1);
   });
 
-  it('detects reuse of a retired token and revokes the session', async () => {
+  it('accepts the just-retired token within the grace window', async () => {
     const cookie1 = getRefreshCookie(await signup());
 
-    const r1 = await refresh(cookie1!);
+    const r1 = await refresh(cookie1!); // rotates; cookie1 becomes the prev token
     expect(r1.status).toBe(200);
-    const cookie2 = getRefreshCookie(r1);
 
-    // Replaying the old (rotated-out) token is treated as theft.
+    // A racing request still holding the just-retired token succeeds (it's the
+    // concurrent-refresh case, not theft).
+    const racing = await refresh(cookie1!);
+    expect(racing.status).toBe(200);
+  });
+
+  it('revokes the session when a long-retired token is replayed', async () => {
+    const cookie1 = getRefreshCookie(await signup()); // token X
+
+    const r1 = await refresh(cookie1!); // X -> X' (prev = X)
+    expect(r1.status).toBe(200);
+    const cookie2 = getRefreshCookie(r1)!;
+
+    const r2 = await refresh(cookie2); // X' -> X'' (prev = X')
+    expect(r2.status).toBe(200);
+
+    // X is now older than the grace token (X'), so replaying it is theft.
     const reuse = await refresh(cookie1!);
     expect(reuse.status).toBe(401);
 
-    // ...and the whole session is revoked, so the legit rotated token fails too.
-    const after = await refresh(cookie2!);
+    // ...and the whole session is revoked: the latest token fails too.
+    const cookie3 = getRefreshCookie(r2)!;
+    const after = await refresh(cookie3);
     expect(after.status).toBe(401);
   });
 

--- a/server/src/test/setup/globalSetup.ts
+++ b/server/src/test/setup/globalSetup.ts
@@ -7,12 +7,15 @@ import {
   PostgreSqlContainer,
   StartedPostgreSqlContainer,
 } from '@testcontainers/postgresql';
+import { GenericContainer, StartedTestContainer } from 'testcontainers';
 
-// The connection string is handed to the worker process through this file,
+// Connection strings are handed to the worker process through these files,
 // because environment variables set here do not cross the process boundary.
 const URL_FILE = join(tmpdir(), 'relates-test-db-url');
+const REDIS_URL_FILE = join(tmpdir(), 'relates-test-redis-url');
 
 let container: StartedPostgreSqlContainer;
+let redisContainer: StartedTestContainer;
 
 export async function setup() {
   container = await new PostgreSqlContainer('postgres:16').start();
@@ -25,9 +28,17 @@ export async function setup() {
   });
 
   writeFileSync(URL_FILE, url);
+
+  redisContainer = await new GenericContainer('redis:7-alpine')
+    .withExposedPorts(6379)
+    .start();
+  const redisUrl = `redis://${redisContainer.getHost()}:${redisContainer.getMappedPort(6379)}`;
+  writeFileSync(REDIS_URL_FILE, redisUrl);
 }
 
 export async function teardown() {
   rmSync(URL_FILE, { force: true });
+  rmSync(REDIS_URL_FILE, { force: true });
   await container?.stop();
+  await redisContainer?.stop();
 }

--- a/server/src/test/setup/resetDb.ts
+++ b/server/src/test/setup/resetDb.ts
@@ -1,9 +1,11 @@
 import { prisma } from '../../db';
+import { redis } from '../../db/redis';
 
-// Empties every table and resets identity sequences, so each test starts from
-// a known-clean state.
+// Empties every table and resets identity sequences, and clears Redis, so each
+// test starts from a known-clean state.
 export async function resetDatabase() {
   await prisma.$executeRawUnsafe(
     'TRUNCATE TABLE "Like", "Repost", "Save", "UserFollows", "Post", "User" RESTART IDENTITY CASCADE',
   );
+  await redis.flushall();
 }

--- a/server/src/test/setup/setupEnv.ts
+++ b/server/src/test/setup/setupEnv.ts
@@ -5,8 +5,10 @@ import { join } from 'node:path';
 // Runs in the worker before any test module is imported, so the database
 // client picks up the test container's connection string.
 const URL_FILE = join(tmpdir(), 'relates-test-db-url');
+const REDIS_URL_FILE = join(tmpdir(), 'relates-test-redis-url');
 
 process.env.DATABASE_URL = readFileSync(URL_FILE, 'utf8').trim();
+process.env.REDIS_URL = readFileSync(REDIS_URL_FILE, 'utf8').trim();
 
 // Test-only signing secrets, so the auth flow can issue and verify tokens.
 process.env.ACCESS_TOKEN_SECRET ||= 'test-access-token-secret';

--- a/server/src/types/express/index.d.ts
+++ b/server/src/types/express/index.d.ts
@@ -1,9 +1,10 @@
-import { UserType } from 'validation';
-
 declare global {
   namespace Express {
     interface Request {
-      user?: UserType;
+      // The authenticated user id, taken from the verified access token.
+      user?: { id: number };
     }
   }
 }
+
+export {};

--- a/server/src/utils/generateTokenAndSetCookie.ts
+++ b/server/src/utils/generateTokenAndSetCookie.ts
@@ -1,34 +1,64 @@
 import { Response } from 'express';
 import jwt from 'jsonwebtoken';
 
+import { newId, storeSession } from './session.js';
+
 const ACCESS_TOKEN_SECRET = process.env.ACCESS_TOKEN_SECRET!;
 const REFRESH_TOKEN_SECRET = process.env.REFRESH_TOKEN_SECRET!;
 
-export function generateTokenAndSetCookie(
+const refreshCookieOptions = {
+  httpOnly: true, // client-side JS cannot access the cookie
+  secure: process.env.NODE_ENV === 'production', // HTTPS-only outside local dev
+  maxAge: 1000 * 60 * 60 * 24 * 7, // 7 days
+  sameSite: 'strict' as const, // CSRF
+};
+
+// Signs a refresh token bound to a session (sid) and a specific token id (jti).
+export function signRefreshToken(
+  userId: number,
+  username: string,
+  profilePic: string | null,
+  sid: string,
+  jti: string,
+): string {
+  return jwt.sign(
+    { userId, username, profilePic, sid, jti },
+    REFRESH_TOKEN_SECRET,
+    { expiresIn: '7d' },
+  );
+}
+
+export function setRefreshCookie(res: Response, token: string): void {
+  res.cookie('refreshToken', token, refreshCookieOptions);
+}
+
+export function clearRefreshCookie(res: Response): void {
+  res.clearCookie('refreshToken', {
+    httpOnly: refreshCookieOptions.httpOnly,
+    secure: refreshCookieOptions.secure,
+    sameSite: refreshCookieOptions.sameSite,
+  });
+}
+
+// Starts a new session: stores it in Redis and sets the refresh cookie.
+export async function generateTokenAndSetCookie(
   userId: number,
   res: Response,
   username: string,
   profilePic: string | null,
-) {
-  const token = jwt.sign(
-    { userId, username, profilePic },
-    REFRESH_TOKEN_SECRET,
-    {
-      expiresIn: '7d',
-    },
-  );
+): Promise<string> {
+  const sid = newId();
+  const jti = newId();
 
-  res.cookie('refreshToken', token, {
-    httpOnly: true, // client-side JS cannot access the cookie
-    secure: process.env.NODE_ENV === 'production', // HTTPS-only outside local dev
-    maxAge: 1000 * 60 * 60 * 24 * 7, // 7 days
-    sameSite: 'strict', // CSRF
-  });
+  await storeSession(userId, sid, jti);
+
+  const token = signRefreshToken(userId, username, profilePic, sid, jti);
+  setRefreshCookie(res, token);
 
   return token;
 }
 
-export function generateAccessToken(userId: number) {
+export function generateAccessToken(userId: number): string {
   return jwt.sign({ userId }, ACCESS_TOKEN_SECRET, {
     expiresIn: '15m',
   });

--- a/server/src/utils/jwtVerify.ts
+++ b/server/src/utils/jwtVerify.ts
@@ -4,6 +4,8 @@ type JwtPayload = {
   userId: number;
   username: string;
   profilePic: string | null;
+  sid?: string; // session id (refresh tokens only)
+  jti?: string; // token id within the session (refresh tokens only)
   iat: number;
   exp: number;
 };

--- a/server/src/utils/session.ts
+++ b/server/src/utils/session.ts
@@ -1,0 +1,57 @@
+import { randomUUID } from 'node:crypto';
+
+import { redis } from '../db/redis.js';
+
+// Sessions expire on their own after the refresh-token lifetime.
+const TTL_SECONDS = 60 * 60 * 24 * 7; // 7 days
+
+const sessionKey = (userId: number, sid: string) => `session:${userId}:${sid}`;
+
+export function newId(): string {
+  return randomUUID();
+}
+
+// Records the currently-valid refresh-token id (jti) for a session.
+export async function storeSession(
+  userId: number,
+  sid: string,
+  jti: string,
+): Promise<void> {
+  await redis.set(sessionKey(userId, sid), jti, 'EX', TTL_SECONDS);
+}
+
+export async function getSessionJti(
+  userId: number,
+  sid: string,
+): Promise<string | null> {
+  return redis.get(sessionKey(userId, sid));
+}
+
+export async function deleteSession(
+  userId: number,
+  sid: string,
+): Promise<void> {
+  await redis.del(sessionKey(userId, sid));
+}
+
+// Removes every session for a user (log out everywhere).
+export async function deleteAllSessions(userId: number): Promise<void> {
+  const pattern = sessionKey(userId, '*');
+  const keys: string[] = [];
+  let cursor = '0';
+  do {
+    const [next, batch] = await redis.scan(
+      cursor,
+      'MATCH',
+      pattern,
+      'COUNT',
+      100,
+    );
+    cursor = next;
+    keys.push(...batch);
+  } while (cursor !== '0');
+
+  if (keys.length > 0) {
+    await redis.del(...keys);
+  }
+}

--- a/server/src/utils/session.ts
+++ b/server/src/utils/session.ts
@@ -6,6 +6,12 @@ import { redis } from '../db/redis.js';
 const TTL_SECONDS = 60 * 60 * 24 * 7; // 7 days
 
 const sessionKey = (userId: number, sid: string) => `session:${userId}:${sid}`;
+const prevKey = (userId: number, sid: string) =>
+  `session:${userId}:${sid}:prev`;
+
+// Grace window during which the just-retired token is still accepted, so two
+// near-simultaneous refreshes (e.g. multiple tabs) don't trip reuse detection.
+const GRACE_SECONDS = 20;
 
 export function newId(): string {
   return randomUUID();
@@ -27,11 +33,27 @@ export async function getSessionJti(
   return redis.get(sessionKey(userId, sid));
 }
 
+// Records the just-retired token id for the grace window.
+export async function storePreviousJti(
+  userId: number,
+  sid: string,
+  jti: string,
+): Promise<void> {
+  await redis.set(prevKey(userId, sid), jti, 'EX', GRACE_SECONDS);
+}
+
+export async function getPreviousJti(
+  userId: number,
+  sid: string,
+): Promise<string | null> {
+  return redis.get(prevKey(userId, sid));
+}
+
 export async function deleteSession(
   userId: number,
   sid: string,
 ): Promise<void> {
-  await redis.del(sessionKey(userId, sid));
+  await redis.del(sessionKey(userId, sid), prevKey(userId, sid));
 }
 
 // Removes every session for a user (log out everywhere).

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -4,11 +4,10 @@ export default defineConfig({
   test: {
     globalSetup: ['./src/test/setup/globalSetup.ts'],
     setupFiles: ['./src/test/setup/setupEnv.ts'],
-    // One database container shared across the run; keep files serial so they
-    // don't race on the shared schema.
+    // One shared database/Redis across the run; keep test files serial so they
+    // don't race on the shared state.
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: { forks: { singleFork: true } },
     include: ['src/**/*.test.ts'],
     testTimeout: 30000,
     hookTimeout: 60000,


### PR DESCRIPTION
## Summary
Replaces stateless JWT-only auth with Redis-backed sessions: refresh tokens become revocable, and the per-request database lookup is removed.

- Session store: each login creates a session (sid); Redis holds the currently valid refresh-token id (jti) per session, with a 7-day TTL.
- Rotation + reuse detection: every refresh issues a new token and retires the old one. Replaying a long-retired token is treated as theft and revokes the session.
- Log out / log out everywhere: logout clears one session; new POST /auth/logout-all clears all of a user's sessions.
- Lookup-free validation: protectRoute trusts the short-lived signed access token instead of loading the user from Postgres on every request; revocation happens at the refresh boundary.
- Grace window: a ~20s window accepts the just-retired token so concurrent refreshes (multiple tabs) don't trip reuse detection.

## Decisions / trade-offs
- Fail closed: if Redis is unreachable during refresh, reject (force re-login).
- Trusting the access token means a deleted account keeps access for up to the 15-minute token lifetime; acceptable, revocation is at the refresh boundary.
- Grace window is "rotation with leeway": a short window where the previous token still works, in exchange for not logging out legitimate concurrent tabs.
- Pre-existing refresh tokens (no sid/jti) are rejected once; users re-login after deploy.

## Infra
- Redis service in docker-compose (persistent, healthchecked); REDIS_URL wired to the server (no .prod.env change needed). Local dev exposes it via the compose override.

## Tests
- Testcontainers Redis added to the harness. New tests cover rotation, reuse detection, the grace window, logout, and logout-all. 21 tests, all green.

## Docs
- README auth/tech sections updated.