### PR TITLE
feat: load balancing and horizontal scaling

### DIFF
--- a/Caddyfile.lb
+++ b/Caddyfile.lb
@@ -1,0 +1,37 @@
+# Caddyfile.lb — local-only load-balancing demo.
+# Same SPA serving as the prod Caddyfile, but /api/v1/* is balanced across two
+# stateless server replicas instead of a single upstream. Mounted over
+# /etc/caddy/Caddyfile by docker-compose.lb.yml so we reuse the client image's
+# built SPA without rebuilding it.
+:80 {
+	# Load-balance API requests across the two replicas.
+	handle /api/v1/* {
+		reverse_proxy server-1:3000 server-2:3000 {
+			# Even, simple distribution across identical stateless workers.
+			lb_policy round_robin
+
+			# Active health checks: Caddy polls each replica's liveness
+			# endpoint and stops routing to one that fails, then re-adds it
+			# when it recovers. This is what makes "kill a replica" seamless.
+			health_uri /api/v1/health
+			health_interval 5s
+			health_timeout 2s
+			health_status 200
+
+			# Passive ejection: if a live request to a replica errors or
+			# times out, take it out of rotation briefly as well.
+			fail_duration 10s
+		}
+	}
+
+	# Serve SPA — try_files equivalent for React Router
+	handle {
+		root * /srv
+		try_files {path} /index.html
+		file_server
+	}
+
+	# Cache static assets
+	@static path *.css *.js *.mjs *.map *.ico *.png *.jpg *.jpeg *.gif *.svg *.webp *.ttf *.woff *.woff2
+	header @static Cache-Control "public, max-age=604800, immutable"
+}

--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ docker kill relates-lb-server-1                       # traffic shifts to the su
 
 Caddy balances `/api/v1/*` across the replicas round-robin, polls each one's `/api/v1/health` liveness probe, and pulls a failing replica out of rotation (re-adding it on recovery). On shutdown each replica handles `SIGTERM` by draining in-flight requests before exiting, so removing one drops no requests.
 
-This is a single-machine demonstration of the pattern; production runs a single replica on a small VPS. At real scale the same shape holds with more replicas behind a managed L7 balancer (for example an ALB) instead of Caddy. The probe and graceful-shutdown handling are the parts that stay identical regardless of the balancer.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Relates is a high-performance, full-stack social media platform inspired by mode
   - [Key Features](#key-features-1)
 - [Packages](#packages)
 - [Performance](#performance)
+- [Horizontal Scaling](#horizontal-scaling)
 - [Getting Started](#getting-started)
 - [License](#license)
 
@@ -67,6 +68,7 @@ A scalable Express backend focused on data integrity and performance.
 - **Blended Feed Logic**: Complex Prisma queries for fetching network-relevant content.
 - **Type-Safe Search**: Case-insensitive partial matching for users and posts.
 - **Rotating Sessions**: Refresh tokens rotate on every use with reuse detection (a replayed token revokes the session); per-request auth validates the signed token without a database lookup.
+- **Stateless & Horizontally Scalable**: No per-request state in process memory (sessions live in Redis), so the API runs behind a load balancer as identical replicas; a `/api/v1/health` liveness probe and graceful `SIGTERM` draining let replicas be added or removed without dropping requests.
 - **Modular Controllers**: Clean separation of concerns for Auth, Post, User, and Search logic.
 
 ## Packages
@@ -95,6 +97,21 @@ The Search column above is the pre-index baseline that motivated the fix; with t
 ```bash
 BENCH_DATABASE_URL=postgresql://user:pass@localhost:5432/relates_bench pnpm --filter server bench
 ```
+
+## Horizontal Scaling
+
+Because sessions live in Redis rather than in process memory, the API is stateless: any replica can serve any request, so it scales horizontally by simply running more copies behind a load balancer. No sticky sessions are needed.
+
+A local-only demo stack (`docker-compose.lb.yml` + `Caddyfile.lb`) runs two `server` replicas behind Caddy:
+
+```bash
+docker compose -f docker-compose.lb.yml up --build   # http://localhost:8080
+docker kill relates-lb-server-1                       # traffic shifts to the survivor, no downtime
+```
+
+Caddy balances `/api/v1/*` across the replicas round-robin, polls each one's `/api/v1/health` liveness probe, and pulls a failing replica out of rotation (re-adding it on recovery). On shutdown each replica handles `SIGTERM` by draining in-flight requests before exiting, so removing one drops no requests.
+
+This is a single-machine demonstration of the pattern; production runs a single replica on a small VPS. At real scale the same shape holds with more replicas behind a managed L7 balancer (for example an ALB) instead of Caddy. The probe and graceful-shutdown handling are the parts that stay identical regardless of the balancer.
 
 ## Getting Started
 

--- a/docker-compose.lb.yml
+++ b/docker-compose.lb.yml
@@ -3,7 +3,7 @@
 # Two stateless `server` replicas behind Caddy, sharing one Postgres and one
 # Redis. Because sessions already live in Redis, any replica can serve any
 # request, so Caddy can round-robin across them. Production stays single-replica
-# (docker-compose.yaml is untouched); this stack is for dev/demo/resume only.
+# (docker-compose.yaml is untouched); this stack is for dev/demo only.
 #
 # Run:   docker compose -f docker-compose.lb.yml up --build
 # Open:  http://localhost:8080

--- a/docker-compose.lb.yml
+++ b/docker-compose.lb.yml
@@ -1,0 +1,113 @@
+# docker-compose.lb.yml — LOCAL-ONLY load-balancing demo.
+#
+# Two stateless `server` replicas behind Caddy, sharing one Postgres and one
+# Redis. Because sessions already live in Redis, any replica can serve any
+# request, so Caddy can round-robin across them. Production stays single-replica
+# (docker-compose.yaml is untouched); this stack is for dev/demo/resume only.
+#
+# Run:   docker compose -f docker-compose.lb.yml up --build
+# Open:  http://localhost:8080
+# Demo:  docker kill relates-lb-server-1   # traffic shifts to server-2, no downtime
+#
+# `name:` isolates this stack's containers, network, and volumes from the prod
+# compose project so the two never collide.
+name: relates-lb
+
+# Shared definition for the two replicas. Both build the same image and read the
+# same env; only the container name and identity differ.
+x-server: &server
+  build:
+    context: .
+    dockerfile: Dockerfile.server
+  image: relates-server:lb
+  env_file:
+    - ./server/.prod.env
+  environment:
+    REDIS_URL: redis://redis:6379
+  depends_on:
+    db:
+      condition: service_healthy
+    redis:
+      condition: service_healthy
+    migrate:
+      condition: service_completed_successfully
+  networks: [appnet]
+  restart: unless-stopped
+
+services:
+  db:
+    image: postgres:16
+    env_file:
+      - ./server/.prod.env
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - lb_pg_data:/var/lib/postgresql/data
+    networks: [appnet]
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - lb_redis_data:/data
+    networks: [appnet]
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  # One-shot: apply migrations before the replicas start serving.
+  migrate:
+    build:
+      context: .
+      dockerfile: Dockerfile.server
+    image: relates-server:lb
+    env_file:
+      - ./server/.prod.env
+    depends_on:
+      db:
+        condition: service_healthy
+    networks: [appnet]
+    restart: "no"
+    working_dir: /app
+    command: ["npx", "prisma", "migrate", "deploy"]
+
+  server-1:
+    <<: *server
+    container_name: relates-lb-server-1
+
+  server-2:
+    <<: *server
+    container_name: relates-lb-server-2
+
+  caddy:
+    build:
+      context: .
+      dockerfile: Dockerfile.client
+    ports:
+      - "8080:80"
+    # Override the image's baked-in Caddyfile with the load-balancing one.
+    volumes:
+      - ./Caddyfile.lb:/etc/caddy/Caddyfile:ro
+    depends_on:
+      - server-1
+      - server-2
+    networks: [appnet]
+    restart: unless-stopped
+
+networks:
+  appnet:
+
+volumes:
+  lb_pg_data:
+  lb_redis_data:

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,3 +1,5 @@
+import os from 'node:os';
+
 import cookieParser from 'cookie-parser';
 import express, { Express } from 'express';
 
@@ -7,6 +9,14 @@ import { userRouter } from './routes/userRoutes.js';
 import { searchRouter } from './routes/searchRoutes.js';
 
 export const app: Express = express();
+
+// Liveness probe for the load balancer's health checks. Deliberately does NOT
+// touch Postgres or Redis: it answers "is this process up and accepting HTTP?"
+// so a slow dependency can't make Caddy eject an otherwise-healthy replica.
+// `instance` is the container hostname, which makes round-robin visible in a demo.
+app.get('/api/v1/health', (_req, res) => {
+  res.status(200).json({ status: 'ok', instance: os.hostname() });
+});
 
 // parse JSON data in the request body
 app.use(express.json());

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,5 +1,5 @@
 import { app } from './app.js';
-import { prisma } from './db/index.js';
+import { prisma } from './db';
 import { redis } from './db/redis.js';
 
 // Handle outside express unhandled promise rejections (e.g. database connection error)

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,4 +1,6 @@
 import { app } from './app.js';
+import { prisma } from './db/index.js';
+import { redis } from './db/redis.js';
 
 // Handle outside express unhandled promise rejections (e.g. database connection error)
 process.on('unhandledRejection', (err) => {
@@ -23,3 +25,37 @@ const PORT = process.env.PORT ? Number(process.env.PORT) : 3001;
 const server = app.listen(PORT, '0.0.0.0', () => {
   console.log(`Server started at ${PORT}`);
 });
+
+// Graceful shutdown. When the load balancer ejects a replica and the container
+// is stopped, Docker sends SIGTERM. We stop accepting new connections, let
+// in-flight requests finish, then close Redis and Postgres so nothing is cut
+// off mid-request. A hard timeout guarantees the process still exits if a
+// connection refuses to drain.
+let shuttingDown = false;
+
+async function shutdown(signal: string): Promise<void> {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log(`${signal} received, shutting down gracefully...`);
+
+  const forceExit = setTimeout(() => {
+    console.error('Could not drain in time, forcing exit.');
+    process.exit(1);
+  }, 10_000);
+  forceExit.unref();
+
+  server.close(async () => {
+    try {
+      await redis.quit();
+      await prisma.$disconnect();
+    } catch (err) {
+      console.error('Error during shutdown cleanup:', err);
+    }
+    clearTimeout(forceExit);
+    console.log('Shutdown complete.');
+    process.exit(0);
+  });
+}
+
+process.on('SIGTERM', () => void shutdown('SIGTERM'));
+process.on('SIGINT', () => void shutdown('SIGINT'));

--- a/server/src/test/health.test.ts
+++ b/server/src/test/health.test.ts
@@ -1,0 +1,19 @@
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+
+import { app } from '../app';
+
+// The health endpoint is the load balancer's liveness probe. Its contract:
+// answer 200 to anyone, without authentication and without depending on the
+// database or Redis, so a slow dependency can't cause a healthy replica to be
+// ejected from the pool.
+describe('health endpoint', () => {
+  it('returns 200 with an ok status and an instance id, unauthenticated', async () => {
+    const res = await request(app).get('/api/v1/health');
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ok');
+    expect(typeof res.body.instance).toBe('string');
+    expect(res.body.instance.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## What and why

Sessions live in Redis, so the API holds no per-request state in process memory and any replica can serve any request. This proves that by running it behind a load balancer as identical replicas, and adds the two pieces that make adding or removing a replica lossless: a liveness probe and graceful shutdown.

## Changes

- **`GET /api/v1/health`** — liveness probe returning `200 {status, instance}`, with no Postgres/Redis dependency, so a slow dependency can't cause the balancer to eject a healthy replica. Includes the container hostname to make round-robin observable.
- **Graceful shutdown** — `SIGTERM`/`SIGINT` handler that stops accepting new connections, drains in-flight requests, closes Redis + Prisma, with a 10s hard-timeout fallback. Lets a replica be stopped without dropping requests.
- **Local LB stack** — `docker-compose.lb.yml` + `Caddyfile.lb`: two stateless `server` replicas behind Caddy with round-robin balancing, active health checks against `/api/v1/health`, and passive ejection. Isolated compose project; prod compose unchanged.
- **Test** — pins the health endpoint's liveness contract (200, unauthenticated, no dependencies).
- **Docs** — README "Horizontal Scaling" section and a stateless/scalable feature bullet.

## Verification

- Typecheck clean; full suite 22 passing (Testcontainers Postgres + Redis).
- Brought the stack up locally: round-robin alternated between replicas; `docker kill --signal=SIGTERM relates-lb-server-1` drained cleanly and every request stayed `200`; the restarted replica rejoined the pool. Torn down after.