### PR TITLE
feat: transactional integrity for denormalized counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ A scalable Express backend focused on data integrity and performance.
 - **Soft-Delete System**: Database-safe post removal ensuring data integrity and relationship stability.
 - **Blended Feed Logic**: Complex Prisma queries for fetching network-relevant content.
 - **Type-Safe Search**: Case-insensitive partial matching for users and posts.
+- **Consistent Counters**: Denormalized counts (likes, reposts, followers, comments) are updated together with their underlying rows inside a transaction, so a partial failure can never leave a count out of step; concurrent duplicate actions are idempotent via unique constraints.
 - **Rotating Sessions**: Refresh tokens rotate on every use with reuse detection (a replayed token revokes the session); per-request auth validates the signed token without a database lookup.
 - **Stateless & Horizontally Scalable**: No per-request state in process memory (sessions live in Redis), so the API runs behind a load balancer as identical replicas; a `/api/v1/health` liveness probe and graceful `SIGTERM` draining let replicas be added or removed without dropping requests.
 - **Modular Controllers**: Clean separation of concerns for Auth, Post, User, and Search logic.

--- a/server/src/controllers/postControllers/createPostController.ts
+++ b/server/src/controllers/postControllers/createPostController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { PostCreateSchema } from 'validation';
 
+import { Prisma } from '../../../generated/prisma/client';
 import { prisma } from '../../db';
 import { PostCreateParamsSchema } from '../../types/validation/schemas.js';
 
@@ -24,25 +25,7 @@ export async function createPost(req: Request, res: Response): Promise<void> {
 
     const parentPostId = params.data.parentPostId;
 
-    // If it's a comment, verify that the parent post exists and increment `commentsCount`
-    if (parentPostId) {
-      const parentPost = await prisma.post.findUnique({
-        where: { id: parentPostId },
-      });
-
-      if (!parentPost) {
-        res.status(404).json({ message: 'Parent post not found' });
-        return;
-      }
-
-      await prisma.post.update({
-        where: { id: parentPostId },
-        data: { commentsCount: { increment: 1 } },
-      });
-    }
-
-    // create post
-    const post = await prisma.post.create({
+    const postArgs = {
       data: {
         postedById: currentUserId,
         text,
@@ -58,7 +41,34 @@ export async function createPost(req: Request, res: Response): Promise<void> {
           },
         },
       },
-    });
+    } satisfies Prisma.PostCreateArgs;
+
+    let post;
+    if (parentPostId) {
+      // It's a comment: verify the parent exists, then create the comment and
+      // bump the parent's commentsCount together so the count can't drift from
+      // the actual number of replies if a write fails partway.
+      const parentPost = await prisma.post.findUnique({
+        where: { id: parentPostId },
+      });
+
+      if (!parentPost) {
+        res.status(404).json({ message: 'Parent post not found' });
+        return;
+      }
+
+      const [created] = await prisma.$transaction([
+        prisma.post.create(postArgs),
+        prisma.post.update({
+          where: { id: parentPostId },
+          data: { commentsCount: { increment: 1 } },
+        }),
+      ]);
+      post = created;
+    } else {
+      // Root-level post: no counter to maintain.
+      post = await prisma.post.create(postArgs);
+    }
 
     res.status(201).json({ post });
   } catch (error) {

--- a/server/src/controllers/postControllers/updatePostController.ts
+++ b/server/src/controllers/postControllers/updatePostController.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 
 import { prisma } from '../../db';
 import { PostParamsSchema } from '../../types/validation/schemas.js';
+import { isPrismaErrorCode } from '../../utils/prismaError.js';
 import { PostUpdateSchema } from 'validation';
 
 export async function updatePost(req: Request, res: Response): Promise<void> {
@@ -122,31 +123,35 @@ export async function likeUnlikePost(req: Request, res: Response) {
     });
 
     if (isLiked) {
-      // Unlike post
-      await prisma.like.delete({
-        where: {
-          userId_postId: {
-            postId,
-            userId,
-          },
-        },
-      });
-      await prisma.post.update({
-        where: { id: postId },
-        data: { likesCount: { decrement: 1 } },
-      });
+      // Unlike: drop the row and the counter together so they can't drift.
+      try {
+        await prisma.$transaction([
+          prisma.like.delete({
+            where: { userId_postId: { postId, userId } },
+          }),
+          prisma.post.update({
+            where: { id: postId },
+            data: { likesCount: { decrement: 1 } },
+          }),
+        ]);
+      } catch (err) {
+        // A concurrent unlike already removed the row: nothing left to do.
+        if (!isPrismaErrorCode(err, 'P2025')) throw err;
+      }
     } else {
-      // Like post
-      await prisma.like.create({
-        data: {
-          userId,
-          postId,
-        },
-      });
-      await prisma.post.update({
-        where: { id: postId },
-        data: { likesCount: { increment: 1 } },
-      });
+      // Like: create the row and bump the counter together.
+      try {
+        await prisma.$transaction([
+          prisma.like.create({ data: { userId, postId } }),
+          prisma.post.update({
+            where: { id: postId },
+            data: { likesCount: { increment: 1 } },
+          }),
+        ]);
+      } catch (err) {
+        // A concurrent like already created the row (unique constraint): no-op.
+        if (!isPrismaErrorCode(err, 'P2002')) throw err;
+      }
     }
     res.status(204).send();
   } catch (error) {
@@ -235,31 +240,35 @@ export async function repostUnrepost(req: Request, res: Response) {
     });
 
     if (isReposted) {
-      // Unrepost post
-      await prisma.repost.delete({
-        where: {
-          userId_postId: {
-            postId,
-            userId,
-          },
-        },
-      });
-      await prisma.post.update({
-        where: { id: postId },
-        data: { repostsCount: { decrement: 1 } },
-      });
+      // Unrepost: drop the row and the counter together so they can't drift.
+      try {
+        await prisma.$transaction([
+          prisma.repost.delete({
+            where: { userId_postId: { postId, userId } },
+          }),
+          prisma.post.update({
+            where: { id: postId },
+            data: { repostsCount: { decrement: 1 } },
+          }),
+        ]);
+      } catch (err) {
+        // A concurrent unrepost already removed the row: nothing left to do.
+        if (!isPrismaErrorCode(err, 'P2025')) throw err;
+      }
     } else {
-      // Repost post
-      await prisma.repost.create({
-        data: {
-          userId,
-          postId,
-        },
-      });
-      await prisma.post.update({
-        where: { id: postId },
-        data: { repostsCount: { increment: 1 } },
-      });
+      // Repost: create the row and bump the counter together.
+      try {
+        await prisma.$transaction([
+          prisma.repost.create({ data: { userId, postId } }),
+          prisma.post.update({
+            where: { id: postId },
+            data: { repostsCount: { increment: 1 } },
+          }),
+        ]);
+      } catch (err) {
+        // A concurrent repost already created the row (unique constraint): no-op.
+        if (!isPrismaErrorCode(err, 'P2002')) throw err;
+      }
     }
     res.status(204).send();
   } catch (error) {

--- a/server/src/controllers/postControllers/updatePostController.ts
+++ b/server/src/controllers/postControllers/updatePostController.ts
@@ -74,19 +74,24 @@ export async function deletePostById(
       return;
     }
 
-    // Mark the post as deleted
-    await prisma.post.update({
-      where: { id: postId },
-      data: { isDeleted: true },
-    });
-
-    // If it's a reply, decrement parent's comment count
-    if (post.parentPostId) {
-      await prisma.post.update({
-        where: { id: post.parentPostId },
-        data: { commentsCount: { decrement: 1 } },
+    // Soft-delete the post and, if it's a reply, decrement the parent's comment
+    // count in the same transaction so they can't drift apart. The updateMany
+    // with `isDeleted: false` makes this idempotent: a repeat delete affects
+    // zero rows (count === 0), so we skip the decrement and the parent's count
+    // can't fall below the real number of replies.
+    await prisma.$transaction(async (tx) => {
+      const { count } = await tx.post.updateMany({
+        where: { id: postId, isDeleted: false },
+        data: { isDeleted: true },
       });
-    }
+
+      if (count > 0 && post.parentPostId) {
+        await tx.post.update({
+          where: { id: post.parentPostId },
+          data: { commentsCount: { decrement: 1 } },
+        });
+      }
+    });
 
     res.status(204).send();
   } catch (error) {

--- a/server/src/controllers/userController.ts
+++ b/server/src/controllers/userController.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import { UserUpdateSchema } from 'validation';
 
 import { prisma } from '../db';
+import { isPrismaErrorCode } from '../utils/prismaError.js';
 import { jwtVerify } from '../utils/jwtVerify.js';
 
 export async function followUnfollowUser(
@@ -39,44 +40,57 @@ export async function followUnfollowUser(
     });
 
     if (isFollowing) {
-      // Unfollow user
-      await prisma.userFollows.delete({
-        where: {
-          followerId_followingId: {
-            followerId: currentUserId,
-            followingId: targetUserId,
-          },
-        },
-      });
-      // update followers and following count
-      await prisma.user.update({
-        where: { id: targetUserId },
-        data: { followersCount: { decrement: 1 } },
-      });
-      await prisma.user.update({
-        where: { id: currentUserId },
-        data: { followingCount: { decrement: 1 } },
-      });
+      // Unfollow: remove the edge and adjust both users' counters together,
+      // so the relationship row and the two counts can never drift apart.
+      try {
+        await prisma.$transaction([
+          prisma.userFollows.delete({
+            where: {
+              followerId_followingId: {
+                followerId: currentUserId,
+                followingId: targetUserId,
+              },
+            },
+          }),
+          prisma.user.update({
+            where: { id: targetUserId },
+            data: { followersCount: { decrement: 1 } },
+          }),
+          prisma.user.update({
+            where: { id: currentUserId },
+            data: { followingCount: { decrement: 1 } },
+          }),
+        ]);
+      } catch (err) {
+        // A concurrent unfollow already removed the edge: nothing left to do.
+        if (!isPrismaErrorCode(err, 'P2025')) throw err;
+      }
 
       res.status(204).send();
       return;
     } else {
-      // Follow user
-      await prisma.userFollows.create({
-        data: {
-          followerId: currentUserId,
-          followingId: targetUserId,
-        },
-      });
-      // update followers and following count
-      await prisma.user.update({
-        where: { id: targetUserId },
-        data: { followersCount: { increment: 1 } },
-      });
-      await prisma.user.update({
-        where: { id: currentUserId },
-        data: { followingCount: { increment: 1 } },
-      });
+      // Follow: create the edge and adjust both users' counters together.
+      try {
+        await prisma.$transaction([
+          prisma.userFollows.create({
+            data: {
+              followerId: currentUserId,
+              followingId: targetUserId,
+            },
+          }),
+          prisma.user.update({
+            where: { id: targetUserId },
+            data: { followersCount: { increment: 1 } },
+          }),
+          prisma.user.update({
+            where: { id: currentUserId },
+            data: { followingCount: { increment: 1 } },
+          }),
+        ]);
+      } catch (err) {
+        // A concurrent follow already created the edge (unique constraint): no-op.
+        if (!isPrismaErrorCode(err, 'P2002')) throw err;
+      }
 
       res.status(204).send();
       return;

--- a/server/src/utils/prismaError.ts
+++ b/server/src/utils/prismaError.ts
@@ -1,0 +1,13 @@
+import { Prisma } from '../../generated/prisma/client';
+
+// True when a Prisma call failed with a specific known error code. We use this
+// to make toggle operations idempotent under a race: when two identical
+// requests run at once, the loser hits the @@unique constraint (P2002 on
+// create) or finds the row already gone (P2025 on delete). That is not a real
+// failure, it just means the desired state already holds, so the caller treats
+// it as a no-op instead of a 500.
+export function isPrismaErrorCode(err: unknown, code: string): boolean {
+  return (
+    err instanceof Prisma.PrismaClientKnownRequestError && err.code === code
+  );
+}

--- a/server/test/counters.test.ts
+++ b/server/test/counters.test.ts
@@ -1,0 +1,130 @@
+import request from 'supertest';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { app } from '../src/app';
+import { prisma } from '../src/db';
+import { createPost, secondUser, signup } from './helpers';
+import { resetDatabase } from './setup/resetDb';
+
+function bearer(token: string) {
+  return `Bearer ${token}`;
+}
+
+// These tests guard the denormalized counters (likesCount, repostsCount,
+// followersCount/followingCount, commentsCount) against drifting away from the
+// rows they summarize. The signature assertion is "counter === actual row
+// count": it holds no matter how concurrent toggles interleave, and it is what
+// would have caught the original non-transactional dual-write bug.
+describe('counter integrity', () => {
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  it('keeps likesCount equal to the Like row count under concurrent likes', async () => {
+    const { accessToken } = (await signup()).body;
+    const postId = (await createPost(accessToken, { text: 'hi' })).body.post.id;
+
+    // Fire many identical likes at once (a double-tap race). None should 500.
+    const results = await Promise.all(
+      Array.from({ length: 12 }, () =>
+        request(app)
+          .put(`/api/v1/posts/${postId}/like`)
+          .set('Authorization', bearer(accessToken)),
+      ),
+    );
+    for (const res of results) expect(res.status).toBe(204);
+
+    const rows = await prisma.like.count({ where: { postId } });
+    const post = await prisma.post.findUnique({ where: { id: postId } });
+    expect(post?.likesCount).toBe(rows);
+  });
+
+  it('keeps repostsCount equal to the Repost row count under concurrent reposts', async () => {
+    const { accessToken } = (await signup()).body;
+    const postId = (await createPost(accessToken, { text: 'hi' })).body.post.id;
+
+    const results = await Promise.all(
+      Array.from({ length: 12 }, () =>
+        request(app)
+          .put(`/api/v1/posts/${postId}/repost`)
+          .set('Authorization', bearer(accessToken)),
+      ),
+    );
+    for (const res of results) expect(res.status).toBe(204);
+
+    const rows = await prisma.repost.count({ where: { postId } });
+    const post = await prisma.post.findUnique({ where: { id: postId } });
+    expect(post?.repostsCount).toBe(rows);
+  });
+
+  it('keeps follower/following counts equal to the edge count under concurrent follows', async () => {
+    const alice = (await signup()).body;
+    const bob = (await signup(secondUser)).body;
+
+    const results = await Promise.all(
+      Array.from({ length: 12 }, () =>
+        request(app)
+          .put(`/api/v1/users/follow/${bob.userId}`)
+          .set('Authorization', bearer(alice.accessToken)),
+      ),
+    );
+    for (const res of results) expect(res.status).toBe(204);
+
+    const edges = await prisma.userFollows.count({
+      where: { followerId: alice.userId, followingId: bob.userId },
+    });
+    const target = await prisma.user.findUnique({ where: { id: bob.userId } });
+    const follower = await prisma.user.findUnique({
+      where: { id: alice.userId },
+    });
+    expect(target?.followersCount).toBe(edges);
+    expect(follower?.followingCount).toBe(edges);
+  });
+
+  it('keeps commentsCount equal to the live reply count as replies are added and deleted', async () => {
+    const { accessToken } = (await signup()).body;
+    const parentId = (await createPost(accessToken, { text: 'parent' })).body.post
+      .id;
+
+    // Add three replies under the parent.
+    const replyIds: number[] = [];
+    for (let i = 0; i < 3; i++) {
+      const res = await request(app)
+        .post(`/api/v1/posts/${parentId}`)
+        .set('Authorization', bearer(accessToken))
+        .send({ text: `reply ${i}` });
+      expect(res.status).toBe(201);
+      replyIds.push(res.body.post.id);
+    }
+
+    async function liveReplyCount() {
+      return prisma.post.count({
+        where: { parentPostId: parentId, isDeleted: false },
+      });
+    }
+    async function parentCommentsCount() {
+      const parent = await prisma.post.findUnique({ where: { id: parentId } });
+      return parent?.commentsCount;
+    }
+
+    expect(await parentCommentsCount()).toBe(3);
+    expect(await parentCommentsCount()).toBe(await liveReplyCount());
+
+    // Delete one reply: the count drops to match.
+    await request(app)
+      .delete(`/api/v1/posts/${replyIds[0]}`)
+      .set('Authorization', bearer(accessToken))
+      .expect(204);
+
+    expect(await parentCommentsCount()).toBe(2);
+    expect(await parentCommentsCount()).toBe(await liveReplyCount());
+
+    // Delete the same reply again: idempotent, the count must not drop twice.
+    await request(app)
+      .delete(`/api/v1/posts/${replyIds[0]}`)
+      .set('Authorization', bearer(accessToken))
+      .expect(204);
+
+    expect(await parentCommentsCount()).toBe(2);
+  });
+});


### PR DESCRIPTION
## What and why

The denormalized counts (`likesCount`, `repostsCount`, `commentsCount`, `followersCount`, `followingCount`) were each maintained by a dual write: the row was changed in one statement and the counter in another, with nothing tying them together. A failure between the two left them permanently out of step. This wraps each row-change-plus-counter pair in a single `prisma.$transaction` so they commit together or not at all.

## Changes

- **like / repost** ([updatePostController.ts]): row + counter in one transaction.
- **follow / unfollow** ([userController.ts]): the edge + both users' counters (three writes) in one transaction.
- **create comment / delete reply**: the comment row + parent `commentsCount` in one transaction. The delete is guarded by `updateMany({ isDeleted: false })` so a repeated delete is idempotent and can't decrement the parent twice.
- **Idempotent toggles**: catch the unique-violation (`P2002`) and missing-row (`P2025`) races and return the normal `204`, with the counter change rolled back. New `isPrismaErrorCode` helper.

## Tests

Four counter-integrity tests: concurrent likes, reposts, and follows assert no request 500s and that each counter equals the actual row count (the invariant that would have caught the original drift), plus a comment add/delete lifecycle including the idempotent double-delete. 26 tests green.
