### PR TITLE
feat: add bell with unread dot and a notifications page

### DIFF
--- a/client/src/features/notifications/components/NotificationItem.tsx
+++ b/client/src/features/notifications/components/NotificationItem.tsx
@@ -1,0 +1,47 @@
+import { useNavigate } from 'react-router-dom';
+
+import { UserPic } from '@/components/UserPic/UserPic.tsx';
+import { convertPostTime } from '@/utils/convertPostTime.ts';
+import { Flex, Text } from '@mantine/core';
+
+import { NotificationItem as NotificationData } from '../hooks/useNotifications.ts';
+
+export function NotificationItem({
+  notification,
+}: {
+  notification: NotificationData;
+}) {
+  const navigate = useNavigate();
+  const { type, actor, post, createdAt } = notification;
+
+  // A like points at the post; a follow points at the follower's profile.
+  const destination =
+    type === 'LIKE' && post ? `/posts/${post.id}` : `/user/${actor.username}`;
+
+  return (
+    <Flex
+      gap={12}
+      align="center"
+      onClick={() => navigate(destination)}
+      style={{ cursor: 'pointer', padding: '12px 4px' }}
+    >
+      <UserPic username={actor.username} avatar={actor.profilePic} />
+      <Flex direction="column" style={{ flex: 1, minWidth: 0 }}>
+        <Text size="sm">
+          <Text span fw={700}>
+            @{actor.username}
+          </Text>{' '}
+          {type === 'LIKE' ? 'liked your post' : 'followed you'}
+        </Text>
+        {type === 'LIKE' && post?.text && (
+          <Text size="xs" c="gray.6" truncate>
+            {post.text}
+          </Text>
+        )}
+      </Flex>
+      <Text size="xs" c="gray.6">
+        {convertPostTime(new Date(createdAt))}
+      </Text>
+    </Flex>
+  );
+}

--- a/client/src/features/notifications/hooks/useNotifications.ts
+++ b/client/src/features/notifications/hooks/useNotifications.ts
@@ -1,0 +1,32 @@
+import { axiosInstance } from '@/api/axiosConfig.ts';
+import { useAuthStore } from '@/stores/authStore.ts';
+import { useQuery } from '@tanstack/react-query';
+
+export type NotificationItem = {
+  id: number;
+  type: 'LIKE' | 'FOLLOW';
+  read: boolean;
+  createdAt: string;
+  actor: { id: number; username: string; profilePic: string | null };
+  post: { id: number; text: string | null } | null;
+};
+
+type NotificationsResponse = { notifications: NotificationItem[] };
+
+// Fetches the current user's notifications (newest first). Polls on an interval
+// so the unread dot and the list stay fresh without websockets. Disabled when
+// logged out so we don't fire a 401.
+export function useNotifications() {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+
+  return useQuery({
+    queryKey: ['notifications'],
+    queryFn: async (): Promise<NotificationItem[]> => {
+      const response =
+        await axiosInstance.get<NotificationsResponse>('/notifications');
+      return response.data.notifications;
+    },
+    enabled: isAuthenticated,
+    refetchInterval: 30_000,
+  });
+}

--- a/client/src/features/notifications/hooks/useUnreadNotifications.ts
+++ b/client/src/features/notifications/hooks/useUnreadNotifications.ts
@@ -1,0 +1,17 @@
+import { useNotificationSeenStore } from '@/stores/notificationSeenStore.ts';
+
+import { useNotifications } from './useNotifications.ts';
+
+// Derives whether there's anything new since the user last opened the list.
+// The list is newest-first, so we only compare the first item's time.
+export function useUnreadNotifications() {
+  const { data } = useNotifications();
+  const lastSeenAt = useNotificationSeenStore((state) => state.lastSeenAt);
+
+  const newest = data?.[0]?.createdAt;
+  const hasUnread = newest
+    ? new Date(newest).getTime() > lastSeenAt
+    : false;
+
+  return { hasUnread };
+}

--- a/client/src/layouts/NavBarLinks/Actions.ts
+++ b/client/src/layouts/NavBarLinks/Actions.ts
@@ -1,4 +1,5 @@
 import {
+  IconBell,
   IconHeart,
   IconHome,
   IconPlus,
@@ -11,5 +12,6 @@ export const actions = [
   { icon: IconSearch, path: '/search', needAuth: false },
   { icon: IconPlus, path: '/create', needAuth: true },
   { icon: IconHeart, path: '/liked', needAuth: true },
+  { icon: IconBell, path: '/notifications', needAuth: true },
   { icon: IconUser, path: '/profile', needAuth: true },
 ];

--- a/client/src/layouts/NavBarLinks/NavBarLinks.tsx
+++ b/client/src/layouts/NavBarLinks/NavBarLinks.tsx
@@ -1,6 +1,7 @@
 import { useLocation } from 'react-router-dom';
 import { actions } from './Actions.ts';
 import { NavBarLink } from './NavBarLink.tsx';
+import { NotificationNavLink } from './NotificationNavLink.tsx';
 
 export function NavBarLinks({ limit }: { limit?: number }) {
   const location = useLocation();
@@ -14,12 +15,21 @@ export function NavBarLinks({ limit }: { limit?: number }) {
 
   const linksToShow = limit ? actions.slice(0, limit) : actions;
 
-  return linksToShow.map((link) => (
-    <NavBarLink
-      {...link}
-      key={link.path}
-      active={isActive(link.path)}
-      needAuth={link.needAuth}
-    />
-  ));
+  return linksToShow.map((link) =>
+    link.path === '/notifications' ? (
+      <NotificationNavLink
+        {...link}
+        key={link.path}
+        active={isActive(link.path)}
+        needAuth={link.needAuth}
+      />
+    ) : (
+      <NavBarLink
+        {...link}
+        key={link.path}
+        active={isActive(link.path)}
+        needAuth={link.needAuth}
+      />
+    ),
+  );
 }

--- a/client/src/layouts/NavBarLinks/NotificationNavLink.tsx
+++ b/client/src/layouts/NavBarLinks/NotificationNavLink.tsx
@@ -1,0 +1,24 @@
+import { useUnreadNotifications } from '@/features/notifications/hooks/useUnreadNotifications.ts';
+import { Indicator } from '@mantine/core';
+import { IconHome } from '@tabler/icons-react';
+
+import { NavBarLink } from './NavBarLink.tsx';
+
+type NotificationNavLinkProps = {
+  icon: typeof IconHome;
+  path: string;
+  active?: boolean;
+  needAuth?: boolean;
+};
+
+// The bell, with a small dot when there's something unread. Reuses NavBarLink
+// for the click/navigation behavior and just adds the indicator on top.
+export function NotificationNavLink(props: NotificationNavLinkProps) {
+  const { hasUnread } = useUnreadNotifications();
+
+  return (
+    <Indicator color="red" size={10} offset={6} disabled={!hasUnread}>
+      <NavBarLink {...props} />
+    </Indicator>
+  );
+}

--- a/client/src/pages/NotificationsPage.tsx
+++ b/client/src/pages/NotificationsPage.tsx
@@ -1,0 +1,52 @@
+import { useEffect } from 'react';
+
+import { Loading } from '@/components/Loading/Loading.tsx';
+import { NotificationItem } from '@/features/notifications/components/NotificationItem.tsx';
+import { useNotifications } from '@/features/notifications/hooks/useNotifications.ts';
+import { useNotificationSeenStore } from '@/stores/notificationSeenStore.ts';
+import { useTitleStore } from '@/stores/titleStore.ts';
+import { Center, Divider, Stack, Text } from '@mantine/core';
+
+export function NotificationsPage() {
+  const { data, isPending, isError } = useNotifications();
+  const markSeen = useNotificationSeenStore((state) => state.markSeen);
+  const setTitle = useTitleStore((state) => state.setTitle);
+
+  // Opening the page clears the unread dot and sets the header title (covers a
+  // direct visit by URL, where the nav click wouldn't have set it).
+  useEffect(() => {
+    setTitle('Notifications');
+    markSeen();
+  }, [setTitle, markSeen]);
+
+  if (isPending) {
+    return <Loading />;
+  }
+
+  if (isError) {
+    return (
+      <Center py="xl">
+        <Text c="gray.6">Could not load notifications</Text>
+      </Center>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <Center py="xl">
+        <Text c="gray.6">No notifications yet</Text>
+      </Center>
+    );
+  }
+
+  return (
+    <Stack gap={0}>
+      {data.map((notification, index) => (
+        <div key={notification.id}>
+          <NotificationItem notification={notification} />
+          {index < data.length - 1 && <Divider />}
+        </div>
+      ))}
+    </Stack>
+  );
+}

--- a/client/src/routes/AppRoutes.tsx
+++ b/client/src/routes/AppRoutes.tsx
@@ -76,6 +76,23 @@ const router = createBrowserRouter(
           },
           hydrateFallbackElement: <Loading />,
         },
+        {
+          path: 'notifications',
+          async lazy() {
+            const { NotificationsPage } = await import(
+              '../pages/NotificationsPage.tsx'
+            );
+            const { ProtectedRoute } = await import('./ProtectedRoute.tsx');
+            return {
+              Component: () => (
+                <ProtectedRoute>
+                  <NotificationsPage />
+                </ProtectedRoute>
+              ),
+            };
+          },
+          hydrateFallbackElement: <Loading />,
+        },
         ...PostsRoutes(),
         ...UserRoutes(),
         {

--- a/client/src/stores/notificationSeenStore.ts
+++ b/client/src/stores/notificationSeenStore.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+// Tracks when the user last opened their notifications, persisted to
+// localStorage. The unread dot compares the newest notification's time against
+// this, so "unread" is a client-side notion (per device). This keeps the
+// feature backend-free for now; if notifications go server-authoritative later,
+// this is the piece that would move to a read flag.
+type NotificationSeenState = {
+  lastSeenAt: number;
+  markSeen: () => void;
+};
+
+export const useNotificationSeenStore = create<NotificationSeenState>()(
+  persist(
+    (set) => ({
+      lastSeenAt: 0,
+      markSeen: () => set({ lastSeenAt: Date.now() }),
+    }),
+    { name: 'relates-notifications-last-seen' },
+  ),
+);


### PR DESCRIPTION
## Summary

Surfaces the notifications that the backend already produces: a bell in the nav with an unread indicator, and a page listing them. Builds entirely on the existing `GET /notifications` endpoint, no API changes.

- **Bell nav item:** added to the nav `actions`, so it appears in both the desktop sidebar and the mobile footer (both render `NavBarLinks`). A `NotificationNavLink` wraps it in a Mantine `Indicator` that shows a red dot when there's something new.
- **Notifications page (`/notifications`):** protected route listing notifications newest-first, each row showing the actor's avatar, "@user liked your post" / "followed you", and a relative time. A like links to the post; a follow links to the actor's profile. Opening the page clears the dot.
- **Data layer:** a polling `useNotifications` query (refetches every 30s, disabled when logged out), plus `useUnreadNotifications` that derives the dot.

## Decisions / trade-offs

- **Unread is client-side:** a last-seen timestamp persisted to `localStorage` (`notificationSeenStore`); the dot shows when the newest notification is newer than it, and opening the page updates it. This keeps the feature backend-free, the trade-off is it's per-device. If notifications later become server-authoritative, this is the piece that would move to the existing `read` column plus an endpoint.
- **Polling over websockets:** a 30s refetch is enough to keep the dot and list fresh, without adding a realtime transport for a low-frequency signal.
- **Reused `NavBarLink`:** the bell wraps the existing link component rather than duplicating its click/navigation/active logic; only the indicator is added on top.
- **List-only:** no mark-as-read action or pagination yet; the API returns the most recent 50.
