### PR TITLE
feat: re-benchmark search after the full-text upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,11 @@ Benchmarked with a synthetic dataset (up to 100k users / 1M posts, seeded via Po
 | For You feed    | 8 / 10 ms | 14 / 17 ms | 60 / 76 ms   |
 | Following feed  | 5 / 6 ms  | 11 / 13 ms | 50 / 59 ms   |
 | Hot feed        | 4 / 5 ms  | 11 / 12 ms | 61 / 68 ms   |
-| Search          | 11 / 15 ms| 37 / 45 ms | 292 / 353 ms |
+| Search (FTS)    | 3 / 5 ms  | 3 / 8 ms   | 5 / 9 ms     |
 
-`EXPLAIN ANALYZE` showed search doing a sequential scan, a leading-wildcard `ILIKE` can't use a B-tree index, so Postgres reads every row. Relates adds a `pg_trgm` GIN index on post text, so the same query uses a bitmap index scan instead, cutting search at 1M posts from ~290 ms to ~3 ms (about 100x). The feeds sort on unindexed columns; indexes help at moderate scale, and a precomputed (fan-out-on-write) feed is the direction beyond that.
+Search uses PostgreSQL full-text search: a generated `tsvector` column with a GIN index, matched with `websearch_to_tsquery` and ranked by `ts_rank`. `EXPLAIN ANALYZE` confirms a bitmap index scan on the tsvector index, with **sub-millisecond** query execution even at 1M posts (0.06 ms at 10k, ~0.8 ms at 1M); the few-ms end-to-end figures above are HTTP and result hydration, not the search itself.
 
-The Search column above is the pre-index baseline that motivated the fix; with the shipped trigram index, search stays in the low single-digit milliseconds. (The benchmark applies all migrations, so re-running it reflects the indexed search.) Numbers are from local hardware and are directional. Reproduce with:
+Originally search was `text ILIKE '%term%'`, a sequential scan that read every row (~290 ms at 1M). A `pg_trgm` GIN index fixed the latency (substring matching via a bitmap index scan), and full-text search then added relevance ranking on top at the same sub-millisecond cost, a strong match now outranks an incidental mention, which `ILIKE` could not do. Numbers are from local hardware and are directional. Reproduce with:
 
 ```bash
 BENCH_DATABASE_URL=postgresql://user:pass@localhost:5432/relates_bench pnpm --filter server bench

--- a/server/src/bench/run.ts
+++ b/server/src/bench/run.ts
@@ -94,7 +94,7 @@ async function main() {
       { label: 'For You feed', run: () => request(app).get('/api/v1/posts/for-you?limit=10').set(auth) },
       { label: 'Following feed', run: () => request(app).get('/api/v1/posts/following?limit=10').set(auth) },
       { label: 'Hot feed', run: () => request(app).get('/api/v1/posts/hot?limit=10') },
-      { label: 'Search posts', run: () => request(app).get('/api/v1/search/posts?q=raremarker&limit=10').set(auth) },
+      { label: 'Search posts (FTS)', run: () => request(app).get('/api/v1/search/posts?q=raremarker&limit=10').set(auth) },
     ];
 
     for (const ep of endpoints) {
@@ -114,7 +114,11 @@ async function main() {
       for (const r of rows) console.log('    ' + r['QUERY PLAN']);
     };
     await explain(
-      'search (text ILIKE)',
+      'search (FTS tsvector + ts_rank)',
+      `SELECT id FROM "Post" WHERE "isDeleted" = false AND "searchVector" @@ websearch_to_tsquery('english', 'raremarker') ORDER BY ts_rank("searchVector", websearch_to_tsquery('english', 'raremarker')) DESC, id DESC LIMIT 10`,
+    );
+    await explain(
+      'search (text ILIKE, trigram) — prior approach for contrast',
       `SELECT id FROM "Post" WHERE text ILIKE '%raremarker%' AND "isDeleted" = false ORDER BY "createdAt" DESC LIMIT 10`,
     );
     await explain(


### PR DESCRIPTION
## Summary

Re-runs the benchmark now that post search uses PostgreSQL full-text search, and updates the harness and the README to match. The search `EXPLAIN ANALYZE` previously explained the old `ILIKE` query, which no longer reflects what the endpoint runs.

- Point the benchmark's `EXPLAIN ANALYZE` at the FTS query (`searchVector @@ websearch_to_tsquery` ordered by `ts_rank`), and keep the trigram `ILIKE` plan beside it as a labeled contrast.
- Relabel the search sweep as `Search posts (FTS)` (the endpoint already exercises FTS).
- Refresh the README Performance table's Search row and narrative with the new numbers.

## Results

Median / p95 end-to-end, with the DB-level query plan:

| Dataset | Search FTS (median / p95) | Plan | DB exec |
|---|---|---|---|
| 10k | 3.3 / 4.7 ms | Bitmap Index Scan on the tsvector GIN index | 0.057 ms |
| 100k | 2.6 / 8.1 ms | same | 0.122 ms |
| 1M | 4.6 / 8.8 ms | same | ~0.8 ms |

- The FTS query is sub-millisecond even at 1M and uses the GIN tsvector index; the few-ms endpoint figure is HTTP and hydration, not the search.
- FTS matches the prior trigram `ILIKE` on latency but adds relevance ranking the trigram approach couldn't do, so ranking effectively came for free.

## Notes

- This change is the harness + docs only; no runtime code changed, so the existing test suite is unaffected.
- The benchmark also surfaced an unrelated issue: with no Redis available, the following feed stalls ~8 s before falling back to the read-time query (the fan-out feed's Redis calls block on retries). That's an artifact of running the benchmark without Redis, not a search issue and not representative of the feed's real latency (Redis up → fast). It's tracked as a separate fix and does not affect the search numbers above.