### PR TITLE
feat: fail the following feed fast when Redis is unavailable

### DIFF
--- a/server/src/feed/feedStore.ts
+++ b/server/src/feed/feedStore.ts
@@ -16,6 +16,32 @@ function feedKey(userId: number): string {
   return `feed:${userId}`;
 }
 
+// Fail the feed's Redis reads fast. When Redis is unreachable, ioredis can take
+// several seconds (queueing + reconnect backoff) before a command rejects,
+// which would stall every following-feed request before the read-time fallback
+// kicks in. A short timeout makes the serving path degrade quickly instead.
+function feedRedisTimeoutMs(): number {
+  return Number(process.env.FEED_REDIS_TIMEOUT_MS ?? 500);
+}
+
+export function withFeedTimeout<T>(
+  promise: Promise<T>,
+  label: string,
+): Promise<T> {
+  const ms = feedRedisTimeoutMs();
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`feed redis ${label} timed out after ${ms}ms`)),
+        ms,
+      );
+      // Don't let the timer keep the process alive on its own.
+      timer.unref();
+    }),
+  ]);
+}
+
 // Add one post id into many users' feeds and trim each back to FEED_CAP.
 // Idempotent: re-adding the same id just rewrites the identical score, so a
 // redelivered event can't duplicate a post in a feed.
@@ -66,19 +92,19 @@ export async function getFeedPage(
   limit: number,
 ): Promise<number[]> {
   const max = cursor ? `(${cursor}` : '+inf';
-  const ids = await redis.zrevrangebyscore(
-    feedKey(userId),
-    max,
-    '-inf',
-    'LIMIT',
-    0,
-    limit,
+  const ids = await withFeedTimeout(
+    redis.zrevrangebyscore(feedKey(userId), max, '-inf', 'LIMIT', 0, limit),
+    'getFeedPage',
   );
   return ids.map(Number);
 }
 
 export async function feedExists(userId: number): Promise<boolean> {
-  return (await redis.exists(feedKey(userId))) === 1;
+  const result = await withFeedTimeout(
+    redis.exists(feedKey(userId)),
+    'feedExists',
+  );
+  return result === 1;
 }
 
 // Rebuild a feed from Postgres: the recent root posts of the non-celebrity

--- a/server/test/feed.test.ts
+++ b/server/test/feed.test.ts
@@ -7,6 +7,7 @@ import { handleEvent } from '../src/events/consumer';
 import {
   CELEBRITY_FOLLOWER_THRESHOLD,
   getFeedPage,
+  withFeedTimeout,
 } from '../src/feed/feedStore';
 import { createPost, secondUser, signup } from './helpers';
 import { resetDatabase } from './setup/resetDb';
@@ -141,5 +142,23 @@ describe('feed fan-out', () => {
     expect(res.status).toBe(200);
     const ids = res.body.posts.map((post: { id: number }) => post.id);
     expect(ids).toContain(postId);
+  });
+});
+
+describe('feed redis fast-fail', () => {
+  it('rejects when a feed redis read exceeds the timeout', async () => {
+    process.env.FEED_REDIS_TIMEOUT_MS = '20';
+    try {
+      // A promise that never settles stands in for a hung Redis call.
+      await expect(
+        withFeedTimeout(new Promise(() => {}), 'test'),
+      ).rejects.toThrow(/timed out/);
+    } finally {
+      delete process.env.FEED_REDIS_TIMEOUT_MS;
+    }
+  });
+
+  it('resolves normally when the read is fast', async () => {
+    await expect(withFeedTimeout(Promise.resolve(42), 'test')).resolves.toBe(42);
   });
 });


### PR DESCRIPTION
## Summary

When Redis is unreachable, the following feed stalled ~8 s before responding: the fan-out feed's Redis reads (`feedExists`, `getFeedPage`) sit in ioredis's offline queue and retry with backoff before rejecting, which only then triggers the read-time fallback. This makes those reads fail fast so the fallback kicks in near-instantly.

- Wrap the feed's Redis reads in a short timeout (`withFeedTimeout`, default 500 ms, configurable via `FEED_REDIS_TIMEOUT_MS`).
- On timeout the call rejects, and `getFollowingPosts`'s existing `catch` already falls back to the read-time query.

## Context

Found during the search benchmark, which ran without Redis and measured the following feed at ~8000 ms at every dataset size. In normal production (Redis up) this never triggers, but a Redis outage or slowdown would otherwise hang every following-feed request before degrading.

## Decisions / trade-offs

- **Timeout at the feed's read calls, not the shared client:** keeps the change scoped to the feed. The shared Redis client (and the auth/session paths that use it) is untouched, since auth already has its own failure handling.
- **500 ms default:** Redis reads are sub-millisecond when healthy, so the timeout only ever fires when something is genuinely wrong; it's env-configurable for tuning or tests.
- **Read path only:** `feedExists` and `getFeedPage` are what block during serving. Writes (`addPostToFeeds` from the consumer, `rebuildFeed`) run off the request path or only when Redis is already responding, so they're left as-is.

## Tests

Two tests pin the timeout primitive: `withFeedTimeout` rejects when a call exceeds the timeout and resolves normally when it's fast. The existing happy-path feed tests (fan-out, celebrity merge, rebuild) still pass, confirming the wrapper doesn't disturb normal Redis-up behavior. 47 tests green; typecheck clean.