### PR TITLE
feat: wire up repost and share, add isReposted to the API

### DIFF
--- a/client/src/features/posts/components/PostActions/PostActions.module.css
+++ b/client/src/features/posts/components/PostActions/PostActions.module.css
@@ -3,6 +3,10 @@
   stroke: var(--mantine-color-red-5);
 }
 
+.reposted {
+  stroke: var(--mantine-color-green-6);
+}
+
 .count {
   margin-bottom: 4px;
   color: var(--mantine-color-gray-7);

--- a/client/src/features/posts/components/PostActions/PostActions.tsx
+++ b/client/src/features/posts/components/PostActions/PostActions.tsx
@@ -12,7 +12,9 @@ import { Post } from '../../hooks/usePostList.ts';
 import { useCreatePostModal } from '@/hooks/useCreatePostModal.tsx';
 import { useAuthStore } from '@/stores/authStore.ts';
 import { useLoginModal } from '@/hooks/useLoginModal.tsx';
+import { showNotificationSuccess } from '@/utils/showNotifications.tsx';
 import { useLikePost } from '../../hooks/useLikePost.ts';
+import { useRepostPost } from '../../hooks/useRepostPost.ts';
 
 type PostActionsProps = {
   post: Post;
@@ -23,8 +25,24 @@ export function PostActions({ post }: PostActionsProps) {
   const openLoginModal = useLoginModal();
   const openCreatePostModal = useCreatePostModal();
   const { mutate: likePost } = useLikePost();
+  const { mutate: repostPost } = useRepostPost();
 
-  const { likesCount, commentsCount, repostsCount, isLiked, id } = post;
+  const { likesCount, commentsCount, repostsCount, isLiked, isReposted, id } =
+    post;
+
+  async function handleShare() {
+    const url = `${window.location.origin}/posts/${id}`;
+    try {
+      await navigator.clipboard.writeText(url);
+      showNotificationSuccess({
+        title: 'Link copied',
+        message: 'Post link copied to your clipboard.',
+      });
+    } catch {
+      // Clipboard can be unavailable (e.g. non-HTTPS); show the link to copy.
+      showNotificationSuccess({ title: 'Share', message: url });
+    }
+  }
 
   return (
     <Group ml={-6} gap={12}>
@@ -61,10 +79,10 @@ export function PostActions({ post }: PostActionsProps) {
           color="green"
           onClick={() => {
             if (!isAuthenticated) return openLoginModal();
-            console.log('repost');
+            repostPost(id);
           }}
         >
-          <IconRepeat />
+          <IconRepeat className={isReposted ? classes.reposted : ''} />
         </PostAction>
         <Text className={classes.count}>
           {repostsCount === 0 ? '' : repostsCount}
@@ -73,8 +91,7 @@ export function PostActions({ post }: PostActionsProps) {
       <PostAction
         color="yellow"
         onClick={() => {
-          if (!isAuthenticated) return openLoginModal();
-          console.log('share');
+          void handleShare();
         }}
       >
         <IconSend />

--- a/client/src/features/posts/hooks/usePostList.ts
+++ b/client/src/features/posts/hooks/usePostList.ts
@@ -23,6 +23,7 @@ export type Post = PostType & {
     };
   };
   isLiked: boolean;
+  isReposted: boolean;
 };
 
 export function usePostsList(endpoint = location.pathname) {

--- a/client/src/features/posts/hooks/useRepostPost.ts
+++ b/client/src/features/posts/hooks/useRepostPost.ts
@@ -1,0 +1,89 @@
+import {
+  InfiniteData,
+  useMutation,
+  useQueryClient,
+} from '@tanstack/react-query';
+
+import { axiosInstance } from '@/api/axiosConfig.ts';
+import { Post } from './usePostList.ts';
+
+type PostsResponse = {
+  posts: Post[];
+  nextCursor: number | null;
+};
+
+type ChildPostsResponse = {
+  comments: Post[];
+  nextCursor: number | null;
+};
+
+type PostResponse = {
+  post: Post;
+  ancestors?: Post[];
+};
+
+export function useRepostPost() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (postId: number) => {
+      await axiosInstance.put(`/posts/${postId}/repost`);
+    },
+    onMutate: async (postId: number) => {
+      await queryClient.cancelQueries({ queryKey: ['posts'] });
+      await queryClient.cancelQueries({ queryKey: ['childposts'] });
+      await queryClient.cancelQueries({ queryKey: ['post', postId] });
+      await queryClient.cancelQueries({ queryKey: ['parentPost', postId] });
+
+      const previousData = queryClient.getQueriesData({ queryKey: [] });
+
+      const updatePost = (post: Post): Post => {
+        if (post.id === postId) {
+          return {
+            ...post,
+            isReposted: !post.isReposted,
+            repostsCount: post.isReposted
+              ? post.repostsCount - 1
+              : post.repostsCount + 1,
+          };
+        }
+        return post;
+      };
+
+      // Update every InfiniteQuery that might contain the post.
+      queryClient.setQueriesData<
+        InfiniteData<PostsResponse | ChildPostsResponse>
+      >({ queryKey: [] }, (old) => {
+        if (!old || !('pages' in old)) return old;
+
+        return {
+          ...old,
+          pages: old.pages.map((page) => {
+            if ('posts' in page) {
+              return { ...page, posts: page.posts.map(updatePost) };
+            }
+            if ('comments' in page) {
+              return { ...page, comments: page.comments.map(updatePost) };
+            }
+            return page;
+          }),
+        };
+      });
+
+      // Update single-post queries (getPostById / parentPost).
+      queryClient.setQueriesData<PostResponse>({ queryKey: [] }, (old) => {
+        if (!old || !('post' in old) || old.post.id !== postId) return old;
+        return { ...old, post: updatePost(old.post) };
+      });
+
+      return { previousData };
+    },
+    onError: (_err, _postId, context) => {
+      if (context?.previousData) {
+        context.previousData.forEach(([queryKey, data]) => {
+          queryClient.setQueryData(queryKey, data);
+        });
+      }
+    },
+  });
+}

--- a/server/src/controllers/postControllers/getPostController.ts
+++ b/server/src/controllers/postControllers/getPostController.ts
@@ -11,6 +11,7 @@ import {
   PostParamsSchema,
   PostQuerySchema,
 } from '../../types/validation/schemas.js';
+import { getRepostedSet } from '../../utils/repostStatus.js';
 
 export async function getHotPosts(req: Request, res: Response) {
   try {
@@ -60,9 +61,14 @@ export async function getHotPosts(req: Request, res: Response) {
       cursor: cursor ? { id: cursor } : undefined,
     });
 
+    const reposted = await getRepostedSet(
+      currentUserId,
+      posts.map((p) => p.id),
+    );
     const postsWithIsLiked = posts.map((post) => ({
       ...post,
       isLiked: (post.likes?.length ?? 0) > 0,
+      isReposted: reposted.has(post.id),
       likes: undefined,
     }));
 
@@ -143,9 +149,14 @@ export async function getForYouPosts(req: Request, res: Response) {
       },
     });
 
+    const reposted = await getRepostedSet(
+      currentUserId,
+      posts.map((p) => p.id),
+    );
     const postsWithIsLiked = posts.map((post) => ({
       ...post,
       isLiked: post.likes.length > 0,
+      isReposted: reposted.has(post.id),
       likes: undefined,
     }));
 
@@ -180,9 +191,14 @@ async function hydratePostsByIds(ids: number[], currentUserId: number) {
     },
   });
 
+  const reposted = await getRepostedSet(
+    currentUserId,
+    posts.map((p) => p.id),
+  );
   return posts.map((post) => ({
     ...post,
     isLiked: post.likes.length > 0,
+    isReposted: reposted.has(post.id),
     likes: undefined,
   }));
 }
@@ -255,9 +271,14 @@ async function readTimeFollowingFeed(
     },
   });
 
+  const reposted = await getRepostedSet(
+    currentUserId,
+    posts.map((p) => p.id),
+  );
   const shaped = posts.map((post) => ({
     ...post,
     isLiked: post.likes.length > 0,
+    isReposted: reposted.has(post.id),
     likes: undefined,
   }));
   const nextCursor = posts.length > 0 ? posts[posts.length - 1].id : null;
@@ -368,9 +389,14 @@ export async function getLikedPosts(req: Request, res: Response) {
       },
     });
 
+    const reposted = await getRepostedSet(
+      currentUserId,
+      posts.map((p) => p.id),
+    );
     const postsWithIsLiked = posts.map((post) => ({
       ...post,
       isLiked: true,
+      isReposted: reposted.has(post.id),
     }));
 
     const nextCursor = posts.length > 0 ? posts[posts.length - 1].id : null;
@@ -434,9 +460,14 @@ export async function getSavedPosts(req: Request, res: Response) {
       },
     });
 
+    const reposted = await getRepostedSet(
+      currentUserId,
+      posts.map((p) => p.id),
+    );
     const postsWithIsLiked = posts.map((post) => ({
       ...post,
       isLiked: post.likes.length > 0,
+      isReposted: reposted.has(post.id),
       likes: undefined,
     }));
 
@@ -502,6 +533,7 @@ export async function getPostById(req: Request, res: Response): Promise<void> {
     const postWithIsLiked = {
       ...post,
       isLiked: (post.likes?.length ?? 0) > 0,
+      isReposted: (await getRepostedSet(currentUserId, [post.id])).has(post.id),
       likes: undefined,
     };
 
@@ -533,6 +565,9 @@ export async function getPostById(req: Request, res: Response): Promise<void> {
       ancestors.unshift({
         ...parent,
         isLiked: (parent.likes?.length ?? 0) > 0,
+        isReposted: (await getRepostedSet(currentUserId, [parent.id])).has(
+          parent.id,
+        ),
         likes: undefined,
       });
       currentParentPostId = parent.parentPostId;
@@ -595,9 +630,14 @@ export async function getPostComments(req: Request, res: Response) {
       },
     });
 
+    const reposted = await getRepostedSet(
+      currentUserId,
+      comments.map((c) => c.id),
+    );
     const commentsWithIsLiked = comments.map((comment) => ({
       ...comment,
       isLiked: (comment.likes?.length ?? 0) > 0,
+      isReposted: reposted.has(comment.id),
       likes: undefined,
     }));
 

--- a/server/src/controllers/postControllers/getUserPostsController.ts
+++ b/server/src/controllers/postControllers/getUserPostsController.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 
 import { prisma } from '../../db';
 import { PostQuerySchema } from '../../types/validation/schemas.js';
+import { getRepostedSet } from '../../utils/repostStatus.js';
 
 export async function getPostsByUsername(
   req: Request<{ username: string }>,
@@ -55,9 +56,14 @@ export async function getPostsByUsername(
       cursor: cursor ? { id: cursor } : undefined,
     });
 
+    const reposted = await getRepostedSet(
+      currentUserId,
+      posts.map((p) => p.id),
+    );
     const postsWithIsLiked = posts.map((post) => ({
       ...post,
       isLiked: (post.likes?.length ?? 0) > 0,
+      isReposted: reposted.has(post.id),
       likes: undefined,
     }));
 
@@ -127,9 +133,14 @@ export async function getCommentsByUsername(
       cursor: cursor ? { id: cursor } : undefined,
     });
 
+    const reposted = await getRepostedSet(
+      currentUserId,
+      comments.map((c) => c.id),
+    );
     const commentsWithIsLiked = comments.map((comment) => ({
       ...comment,
       isLiked: (comment.likes?.length ?? 0) > 0,
+      isReposted: reposted.has(comment.id),
       likes: undefined,
     }));
 

--- a/server/src/controllers/searchController.ts
+++ b/server/src/controllers/searchController.ts
@@ -3,6 +3,7 @@ import { prisma } from '../db';
 import { isEsEnabled } from '../search/esClient.js';
 import { searchPostIds } from '../search/postIndex.js';
 import { SearchQuerySchema } from '../types/validation/schemas.js';
+import { getRepostedSet } from '../utils/repostStatus.js';
 
 // Ranked matching post ids from Postgres full-text search (offset-paged). Used
 // when Elasticsearch isn't configured (e.g. production).
@@ -81,6 +82,10 @@ export async function searchPosts(req: Request, res: Response) {
     });
 
     // findMany doesn't preserve the `in` order, so restore the rank order.
+    const reposted = await getRepostedSet(
+      currentUserId,
+      posts.map((post) => post.id),
+    );
     const byId = new Map(posts.map((post) => [post.id, post]));
     const postsWithIsLiked = ids
       .map((id) => byId.get(id))
@@ -88,6 +93,7 @@ export async function searchPosts(req: Request, res: Response) {
       .map((post) => ({
         ...post,
         isLiked: (post.likes?.length ?? 0) > 0,
+        isReposted: reposted.has(post.id),
         likes: undefined,
       }));
 

--- a/server/src/utils/repostStatus.ts
+++ b/server/src/utils/repostStatus.ts
@@ -1,0 +1,18 @@
+import { prisma } from '../db/index.js';
+
+// Returns the subset of postIds that the current user has reposted, as a Set for
+// O(1) lookup while shaping responses. One batched query per list, mirroring how
+// `isLiked` is derived but without threading a relation include through every
+// post query. Empty for anonymous callers.
+export async function getRepostedSet(
+  currentUserId: number | undefined,
+  postIds: number[],
+): Promise<Set<number>> {
+  if (!currentUserId || postIds.length === 0) return new Set();
+
+  const rows = await prisma.repost.findMany({
+    where: { userId: currentUserId, postId: { in: postIds } },
+    select: { postId: true },
+  });
+  return new Set(rows.map((row) => row.postId));
+}

--- a/server/test/posts.test.ts
+++ b/server/test/posts.test.ts
@@ -66,6 +66,41 @@ describe('post interactions and authorization', () => {
     expect(res.body.post.likesCount).toBe(2);
   });
 
+  it('reflects the viewer repost state via isReposted', async () => {
+    const { alice, bob } = await setupTwoUsers();
+    const postId = (await createPost(alice.accessToken, { text: 'hi' })).body
+      .post.id;
+
+    await request(app)
+      .put(`/api/v1/posts/${postId}/repost`)
+      .set('Authorization', bearer(bob.accessToken))
+      .expect(204);
+
+    // The reposter sees isReposted true; the author (who didn't repost) sees false.
+    let res = await request(app)
+      .get(`/api/v1/posts/${postId}`)
+      .set('Authorization', bearer(bob.accessToken));
+    expect(res.body.post.isReposted).toBe(true);
+    expect(res.body.post.repostsCount).toBe(1);
+
+    res = await request(app)
+      .get(`/api/v1/posts/${postId}`)
+      .set('Authorization', bearer(alice.accessToken));
+    expect(res.body.post.isReposted).toBe(false);
+    expect(res.body.post.repostsCount).toBe(1);
+
+    // Unrepost flips it back.
+    await request(app)
+      .put(`/api/v1/posts/${postId}/repost`)
+      .set('Authorization', bearer(bob.accessToken))
+      .expect(204);
+    res = await request(app)
+      .get(`/api/v1/posts/${postId}`)
+      .set('Authorization', bearer(bob.accessToken));
+    expect(res.body.post.isReposted).toBe(false);
+    expect(res.body.post.repostsCount).toBe(0);
+  });
+
   it("rejects editing another user's post", async () => {
     const { alice, bob } = await setupTwoUsers();
     const postId = (await createPost(alice.accessToken, { text: 'mine' })).body


### PR DESCRIPTION
## Summary

The repost and share buttons existed in the UI but only logged to the console. Repost has a backend toggle, but the API never told the client whether *you* had reposted (it returns `isLiked` but had no `isReposted`), so the button couldn't toggle or stay highlighted. This adds `isReposted` to post responses and wires both buttons.

- **Backend:** return `isReposted` on every post-serving endpoint (feeds, post detail + ancestors, comments, saved/liked, profile posts/comments, search), mirroring `isLiked`.
- **Repost button:** an optimistic `useRepostPost` hook (same pattern as `useLikePost`) toggles the count and a green highlight instantly, and it persists across reloads now that the API reports the state.
- **Share button:** copies the post link to the clipboard and shows a "Link copied" toast, with a fallback that surfaces the link if the clipboard API is unavailable.

## Decisions / trade-offs

- **`isReposted` via a batched helper, not a relation include:** a single `getRepostedSet(currentUserId, postIds)` query per response returns the reposted ids as a Set, and each mapping site does `isReposted: reposted.has(post.id)`. This avoids threading a `reposts` include through ~12 queries and mirrors how the For You feed already batches liked ids. `isLiked` still uses the relation-include style, so the two derivations differ slightly.
- **Share needs no backend and no login:** copying a public post link is a client-only action, so the share button is available to anyone (the previous code gated it behind login); the clipboard call has a graceful fallback for non-HTTPS/blocked-clipboard contexts.
- **Full parity with like:** chosen over minimal wiring so the repost button toggles correctly and survives reloads, rather than a count-only bump that could desync on rapid re-clicks.

## Tests

Backend test: after a user reposts, that user sees `isReposted: true` while the author sees `false`, and unreposting flips it back (with `repostsCount` tracking). Server suite 48 green; client `tsc -b` and production build clean.
