### PR TITLE
feat: repost and share: wire up, surface reposts on the profile, copy-link share

### DIFF
--- a/client/src/features/posts/components/PostActions/PostActions.tsx
+++ b/client/src/features/posts/components/PostActions/PostActions.tsx
@@ -1,3 +1,5 @@
+import { useNavigate } from 'react-router-dom';
+
 import { Center, Group, Text } from '@mantine/core';
 import {
   IconHeart,
@@ -26,6 +28,7 @@ export function PostActions({ post }: PostActionsProps) {
   const openCreatePostModal = useCreatePostModal();
   const { mutate: likePost } = useLikePost();
   const { mutate: repostPost } = useRepostPost();
+  const navigate = useNavigate();
 
   const { likesCount, commentsCount, repostsCount, isLiked, isReposted, id } =
     post;
@@ -79,7 +82,11 @@ export function PostActions({ post }: PostActionsProps) {
           color="green"
           onClick={() => {
             if (!isAuthenticated) return openLoginModal();
+            const willRepost = !isReposted;
             repostPost(id);
+            // On a repost (not an undo), open the post so the user sees it as
+            // "their" reposted post; unreposting stays put.
+            if (willRepost) void navigate(`/posts/${id}`);
           }}
         >
           <IconRepeat className={isReposted ? classes.reposted : ''} />

--- a/client/src/features/posts/components/PostItem/PostItem.tsx
+++ b/client/src/features/posts/components/PostItem/PostItem.tsx
@@ -1,7 +1,8 @@
 import { useNavigate } from 'react-router-dom';
 
 import { convertPostTime } from '@/utils/convertPostTime.ts';
-import { Divider, Flex } from '@mantine/core';
+import { Divider, Flex, Text } from '@mantine/core';
+import { IconRepeat } from '@tabler/icons-react';
 
 import { Post } from '../../hooks/usePostList.ts';
 import { PostActions } from '../PostActions/PostActions.tsx';
@@ -26,6 +27,12 @@ export function PostItem({ post, withLine, hideDivider }: PostProps) {
         onClick={() => navigate(`/posts/${post.id}`)}
         className={classes.postItem}
       >
+        {post.repostedBy && (
+          <Flex align="center" gap={6} c="gray.6" mb={4} ml={48}>
+            <IconRepeat size={14} />
+            <Text size="xs">Reposted by {post.repostedBy}</Text>
+          </Flex>
+        )}
         <Flex gap={12}>
           <PostLeftBar
             username={post.postedBy.username}

--- a/client/src/features/posts/hooks/usePostList.ts
+++ b/client/src/features/posts/hooks/usePostList.ts
@@ -24,6 +24,8 @@ export type Post = PostType & {
   };
   isLiked: boolean;
   isReposted: boolean;
+  // Set on profile feeds when this item is a repost by the profile's owner.
+  repostedBy?: string | null;
 };
 
 export function usePostsList(endpoint = location.pathname) {

--- a/server/src/controllers/postControllers/getUserPostsController.ts
+++ b/server/src/controllers/postControllers/getUserPostsController.ts
@@ -19,57 +19,99 @@ export async function getPostsByUsername(
     const { username } = req.params;
     const currentUserId = req.user?.id;
 
-    const posts = await prisma.post.findMany({
-      where: { 
-        postedBy: { username }, 
-        parentPostId: null,
-        isDeleted: false
-      },
-      orderBy: { createdAt: 'desc' },
+    const profileUser = await prisma.user.findUnique({
+      where: { username },
+      select: { id: true },
+    });
+    if (!profileUser) {
+      res.status(200).json({ posts: [], nextCursor: null });
+      return;
+    }
+
+    // The profile shows the user's own root posts AND posts they reposted,
+    // interleaved by activity time (a repost's time is when they reposted).
+    // It's a merged list, so we page by offset (the cursor is an offset here).
+    const offset = cursor ?? 0;
+    const fetchN = offset + limit;
+
+    const [authored, reposts] = await Promise.all([
+      prisma.post.findMany({
+        where: {
+          postedById: profileUser.id,
+          parentPostId: null,
+          isDeleted: false,
+        },
+        orderBy: { createdAt: 'desc' },
+        take: fetchN,
+        select: { id: true, createdAt: true },
+      }),
+      prisma.repost.findMany({
+        where: { userId: profileUser.id, post: { isDeleted: false } },
+        orderBy: { createdAt: 'desc' },
+        take: fetchN,
+        select: { postId: true, createdAt: true },
+      }),
+    ]);
+
+    // Merge the two sources, newest activity first, de-duped by post id.
+    const entries = [
+      ...authored.map((post) => ({
+        postId: post.id,
+        activityAt: post.createdAt,
+        isRepost: false,
+      })),
+      ...reposts.map((repost) => ({
+        postId: repost.postId,
+        activityAt: repost.createdAt,
+        isRepost: true,
+      })),
+    ].sort((a, b) => b.activityAt.getTime() - a.activityAt.getTime());
+
+    const seen = new Set<number>();
+    const deduped = entries.filter((entry) => {
+      if (seen.has(entry.postId)) return false;
+      seen.add(entry.postId);
+      return true;
+    });
+    const pageEntries = deduped.slice(offset, offset + limit);
+    const pageIds = pageEntries.map((entry) => entry.postId);
+
+    // Hydrate the page, then restore the merged order.
+    const hydrated = await prisma.post.findMany({
+      where: { id: { in: pageIds } },
       include: {
         postedBy: {
-          select: {
-            id: true,
-            username: true,
-            name: true,
-            profilePic: true,
-          },
+          select: { id: true, username: true, name: true, profilePic: true },
         },
         parentPost: {
-          select: {
-            postedBy: {
-              select: {
-                username: true,
-              },
-            },
-          },
+          select: { postedBy: { select: { username: true } } },
         },
         likes: currentUserId
-          ? {
-              where: { userId: currentUserId },
-              select: { userId: true },
-            }
+          ? { where: { userId: currentUserId }, select: { userId: true } }
           : false,
       },
-      take: limit,
-      skip: cursor ? 1 : 0,
-      cursor: cursor ? { id: cursor } : undefined,
     });
+    const byId = new Map(hydrated.map((post) => [post.id, post]));
+    const reposted = await getRepostedSet(currentUserId, pageIds);
 
-    const reposted = await getRepostedSet(
-      currentUserId,
-      posts.map((p) => p.id),
-    );
-    const postsWithIsLiked = posts.map((post) => ({
-      ...post,
-      isLiked: (post.likes?.length ?? 0) > 0,
-      isReposted: reposted.has(post.id),
-      likes: undefined,
-    }));
+    const posts = pageEntries
+      .map((entry) => {
+        const post = byId.get(entry.postId);
+        if (!post) return null;
+        return {
+          ...post,
+          isLiked: (post.likes?.length ?? 0) > 0,
+          isReposted: reposted.has(post.id),
+          // Attribute reposts so the UI can show "Reposted by <username>".
+          repostedBy: entry.isRepost ? username : null,
+          likes: undefined,
+        };
+      })
+      .filter((post): post is NonNullable<typeof post> => post !== null);
 
-    const nextCursor = posts.length > 0 ? posts[posts.length - 1].id : null;
+    const nextCursor = deduped.length > offset + limit ? offset + limit : null;
 
-    res.status(200).json({ posts: postsWithIsLiked, nextCursor });
+    res.status(200).json({ posts, nextCursor });
   } catch (error) {
     res.status(500).json({ message: 'Unknown error occurred!' });
     console.error('Error in get user posts:', error);

--- a/server/test/posts.test.ts
+++ b/server/test/posts.test.ts
@@ -2,7 +2,7 @@ import request from 'supertest';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { app } from '../src/app';
-import { createPost, secondUser, signup } from './helpers';
+import { createPost, secondUser, signup, validUser } from './helpers';
 import { resetDatabase } from './setup/resetDb';
 
 async function setupTwoUsers() {
@@ -99,6 +99,42 @@ describe('post interactions and authorization', () => {
       .set('Authorization', bearer(bob.accessToken));
     expect(res.body.post.isReposted).toBe(false);
     expect(res.body.post.repostsCount).toBe(0);
+  });
+
+  it("shows a reposted post on the reposter's profile, attributed to them", async () => {
+    const { alice, bob } = await setupTwoUsers();
+    const postId = (await createPost(alice.accessToken, { text: 'alice post' }))
+      .body.post.id;
+
+    await request(app)
+      .put(`/api/v1/posts/${postId}/repost`)
+      .set('Authorization', bearer(bob.accessToken))
+      .expect(204);
+
+    // Bob authored nothing, but his profile shows the post he reposted,
+    // attributed to him while still crediting the original author.
+    let res = await request(app)
+      .get(`/api/v1/posts/user/${secondUser.username}/posts`)
+      .set('Authorization', bearer(bob.accessToken));
+    expect(res.status).toBe(200);
+    const item = res.body.posts.find(
+      (post: { id: number }) => post.id === postId,
+    );
+    expect(item).toBeDefined();
+    expect(item.repostedBy).toBe(secondUser.username);
+    expect(item.postedBy.username).toBe(validUser.username);
+
+    // Unreposting removes it from his profile again.
+    await request(app)
+      .put(`/api/v1/posts/${postId}/repost`)
+      .set('Authorization', bearer(bob.accessToken))
+      .expect(204);
+    res = await request(app)
+      .get(`/api/v1/posts/user/${secondUser.username}/posts`)
+      .set('Authorization', bearer(bob.accessToken));
+    expect(
+      res.body.posts.find((post: { id: number }) => post.id === postId),
+    ).toBeUndefined();
   });
 
   it("rejects editing another user's post", async () => {


### PR DESCRIPTION
## Summary

The repost and share buttons existed in the UI but only logged to the console, and repost had no real effect beyond a counter. This makes both work end to end.

- **Repost** is now a real reshare: clicking it toggles optimistically (count + green highlight), records it via the existing endpoint, surfaces the post on the reposter's profile attributed "🔁 Reposted by X", and opens the post's page so it feels like "your" repost. Clicking again un-reposts and removes it.
- **Share** copies the post link to the clipboard and shows a toast.
- The API now reports `isReposted` per viewer, so the button reflects and persists state.

## Changes

- **`isReposted` on post responses** across all post-serving endpoints (feeds, post detail + ancestors, comments, saved/liked, profile, search), derived with a batched `getRepostedSet(currentUserId, postIds)` helper.
- **Profile reshare:** `getPostsByUsername` merges the user's authored root posts with the posts they reposted, interleaved by activity time (a repost's time is when they reposted), de-duped, with `repostedBy` attribution.
- **Client:** `useRepostPost` optimistic-toggle hook (mirrors `useLikePost`); the `Post` type gains `isReposted` and optional `repostedBy`; `PostItem` renders a "Reposted by X" header; the repost button highlights, navigates to the post on repost, and the share button copies the link with a toast.

## Decisions / trade-offs

- **`isReposted` via a batched helper, not a relation include:** one query per response returning a Set, rather than threading a `reposts` include through ~12 queries. `isLiked` still uses the include style, so the two derivations differ slightly.
- **Profile uses offset pagination:** it's now a merged list (authored + reposts ordered by activity time), which an id cursor can't page, so the cursor is treated as an offset there (same approach as search; no client change).
- **Share needs no backend or login:** copying a public link is client-only; it has a fallback that surfaces the link if the clipboard API is blocked (e.g. non-HTTPS).

## Tests

Backend (Testcontainers): `isReposted` reflects the viewer's repost and flips on un-repost; a reposted post appears on the reposter's profile attributed to them (crediting the original author) and disappears on un-repost. 49 tests green; server and client typecheck and build clean.

## No schema changes

Uses the existing `Repost` table and repost toggle endpoint; this PR exposes per-viewer state and the profile/UI surfacing.