### PR TITLE
fix: keep profile tab navigation on the viewed user

### DIFF
--- a/client/src/pages/UserPage.tsx
+++ b/client/src/pages/UserPage.tsx
@@ -44,7 +44,7 @@ export function UserPage() {
     <>
       <UserHeader
         tab={activeTab}
-        onTabChange={(tab) => navigate(`/profile/${tab}`)}
+        onTabChange={(tab) => navigate(`/user/${username}/${tab}`)}
         user={user}
       />
       <PostList endpoint={endPoint} />


### PR DESCRIPTION
Switching tabs (Posts / Comments) on another user's profile navigated to /profile/:tab, which redirects to the logged-in user's own profile — so viewing someone else's profile and clicking "Comments" kicked you to yourself.

The tab handler now navigates to the profile being viewed (/user/:username/:tab) using the username from the route, so tabs stay on the current profile. Viewing your own profile is unaffected (it already resolves to /user/<you>/<tab>).

One-line change in UserPage.tsx; client typecheck and build pass.