### PR TITLE
fix: default to light mode and clarify the theme toggle label

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Relates
 
-A full-stack, threads-style social media platform that started as a synchronous CRUD app and was deliberately evolved into an **event-driven, derived-state architecture**, the way the system-design playbook teaches it: PostgreSQL owns correctness, committed changes become events, and consumers build the read-optimized views each feature needs.
+A full-stack social media platform that started as a synchronous CRUD app and was deliberately evolved into an **event-driven, derived-state architecture**, the way the system-design playbook teaches it: PostgreSQL owns correctness, committed changes become events, and consumers build the read-optimized views each feature needs.
 
 **Stack:** TypeScript · React · Express · PostgreSQL · Prisma · Redis · Kafka (Redpanda) · Elasticsearch · Docker · AWS EC2
 
 **Status:** Deployed to AWS EC2 behind Cloudflare + Caddy, serving active users. The heavier streaming/search-cluster pieces run locally by design (see [Production vs. local](#production-vs-local)).
+
+**Live demo:** https://relatesapp.com
 
 ---
 

--- a/client/src/components/Logo/Logo.tsx
+++ b/client/src/components/Logo/Logo.tsx
@@ -10,7 +10,7 @@ import {
 
 export function Logo() {
   const navigate = useNavigate();
-  const computedColorScheme = useComputedColorScheme('dark');
+  const computedColorScheme = useComputedColorScheme('light');
 
   return (
     <Flex justify="center">

--- a/client/src/layouts/Footer/Footer.tsx
+++ b/client/src/layouts/Footer/Footer.tsx
@@ -10,7 +10,7 @@ import classes from '../Navbar/NavBarButtons.module.css';
 export function Footer() {
   const navigate = useNavigate();
   const { setColorScheme } = useMantineColorScheme();
-  const computedColorScheme = useComputedColorScheme('dark');
+  const computedColorScheme = useComputedColorScheme('light');
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const mutation = useLogoutMutation();
 
@@ -56,7 +56,7 @@ export function Footer() {
             }
             onClick={toggleColorScheme}
           >
-            Appearance
+            {computedColorScheme === 'dark' ? 'Light Mode' : 'Dark Mode'}
           </Menu.Item>
           {isAuthenticated && (
             <>

--- a/client/src/layouts/Navbar/NavBar.tsx
+++ b/client/src/layouts/Navbar/NavBar.tsx
@@ -19,7 +19,7 @@ import classes from './NavBarButtons.module.css';
 export function NavBar() {
   const navigate = useNavigate();
   const { setColorScheme } = useMantineColorScheme();
-  const computedColorScheme = useComputedColorScheme('dark');
+  const computedColorScheme = useComputedColorScheme('light');
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
 
   const toggleColorScheme = () => {
@@ -63,7 +63,7 @@ export function NavBar() {
               }
               onClick={toggleColorScheme}
             >
-              Appearance
+              {computedColorScheme === 'dark' ? 'Light Mode' : 'Dark Mode'}
             </Menu.Item>
             {isAuthenticated && (
               <>

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -16,7 +16,7 @@ import './index.css';
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
-      <MantineProvider theme={theme} defaultColorScheme="dark">
+      <MantineProvider theme={theme} defaultColorScheme="light">
         <ModalsProvider>
           <Notifications />
           <App />


### PR DESCRIPTION
## Summary

Changes the app's default appearance to light mode and makes the theme menu label describe the action it will take.

- Default Mantine color scheme is now `light`.
- The theme toggle now shows `Dark Mode` while in light mode.
- The theme toggle now shows `Light Mode` while in dark mode.
- Updated color-scheme fallbacks in the nav/footer/logo to match the new default.

## Verification

- Client typecheck passed.
- Client production build passed.