### PR TITLE
fix: duplicate history entries in post threads and profile tabs

### DIFF
--- a/client/src/features/comments/PostWithComments/PostWithComments.tsx
+++ b/client/src/features/comments/PostWithComments/PostWithComments.tsx
@@ -46,7 +46,11 @@ export function PostWithComments() {
       {/* Render Ancestor (only the immediate parent) */}
       {ancestors.length > 0 && (
         <Box pb="md">
-          <PostItem post={ancestors[ancestors.length - 1]} hideDivider />
+          <PostItem
+            post={ancestors[ancestors.length - 1]}
+            hideDivider
+            replaceOnClick
+          />
           <Divider mx={-16} mt="md" />
         </Box>
       )}
@@ -54,7 +58,11 @@ export function PostWithComments() {
       {/* Render Current Post */}
       {parentPost && (
         <Box pt="md" pb="md">
-          <PostItem post={parentPost} hideDivider />
+          <PostItem
+            post={parentPost}
+            hideDivider
+            clickTarget={null}
+          />
         </Box>
       )}
 
@@ -70,7 +78,9 @@ export function PostWithComments() {
       {/* Render Child Posts */}
       <Stack gap="md">
         {childPostsData?.pages.map((page) =>
-          page.comments.map((post) => <PostItem post={post} key={post.id} />),
+          page.comments.map((post) => (
+            <PostItem post={post} key={post.id} replaceOnClick />
+          )),
         )}
       </Stack>
 

--- a/client/src/features/posts/components/PostItem/PostItem.module.css
+++ b/client/src/features/posts/components/PostItem/PostItem.module.css
@@ -1,5 +1,8 @@
 .postItem {
   text-decoration: none;
   color: inherit;
+}
+
+.postItem[data-clickable] {
   cursor: pointer;
 }

--- a/client/src/features/posts/components/PostItem/PostItem.tsx
+++ b/client/src/features/posts/components/PostItem/PostItem.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import { convertPostTime } from '@/utils/convertPostTime.ts';
 import { Divider, Flex, Text } from '@mantine/core';
@@ -16,16 +16,32 @@ type PostProps = {
   post: Post;
   withLine?: boolean;
   hideDivider?: boolean;
+  clickTarget?: string | null;
+  replaceOnClick?: boolean;
 };
 
-export function PostItem({ post, withLine, hideDivider }: PostProps) {
+export function PostItem({
+  post,
+  withLine,
+  hideDivider,
+  clickTarget,
+  replaceOnClick,
+}: PostProps) {
   const navigate = useNavigate();
+  const location = useLocation();
+  const postPath = clickTarget === undefined ? `/posts/${post.id}` : clickTarget;
+
+  const openPost = () => {
+    if (!postPath || location.pathname === postPath) return;
+    void navigate(postPath, { replace: replaceOnClick });
+  };
 
   return (
     <>
       <div
-        onClick={() => navigate(`/posts/${post.id}`)}
+        onClick={openPost}
         className={classes.postItem}
+        data-clickable={postPath ? true : undefined}
       >
         {post.repostedBy && (
           <Flex align="center" gap={6} c="gray.6" mb={4} ml={48}>

--- a/client/src/pages/UserPage.tsx
+++ b/client/src/pages/UserPage.tsx
@@ -26,6 +26,10 @@ export function UserPage() {
   }, [user, currentUser, setTitle]);
 
   const activeTab = tab == 'comments' ? 'comments' : 'posts';
+  const handleTabChange = (nextTab: string) => {
+    if (nextTab === activeTab) return;
+    navigate(`/user/${username}/${nextTab}`, { replace: true });
+  };
 
   if (isLoading) {
     return <Loading />;
@@ -44,7 +48,7 @@ export function UserPage() {
     <>
       <UserHeader
         tab={activeTab}
-        onTabChange={(tab) => navigate(`/user/${username}/${tab}`)}
+        onTabChange={handleTabChange}
         user={user}
       />
       <PostList endpoint={endPoint} />


### PR DESCRIPTION
## Summary

Fixes navigation-history bugs around post threads and profile tabs.

- Clicking the current post on a post detail page no longer reopens the same route.
- Clicking comments inside a post thread opens that comment thread with history replacement, so Back returns to the real previous page.
- Profile Posts/Comments tab switches also use history replacement and ignore same-tab clicks.

## Details

`PostItem` now accepts:
- omitted `clickTarget`: normal behavior, click opens the post
- `clickTarget={null}`: not clickable
- custom `clickTarget`: click opens that path
- `replaceOnClick`: replaces the current history entry instead of pushing

`PostWithComments` uses this so thread-internal navigation does not stack browser history. `UserPage` keeps tab changes on the current profile without adding extra Back steps.

## Verification

- Client typecheck passed.
- Client production build passed.