### PR TITLE
feat: refine comment thread layout

### DIFF
--- a/client/src/features/comments/PostWithComments/PostWithComments.tsx
+++ b/client/src/features/comments/PostWithComments/PostWithComments.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useInView } from 'react-intersection-observer';
 
 import { Loading } from '@/components/Loading/Loading.tsx';
@@ -11,6 +11,7 @@ import { usePostwithChildPosts } from '../../posts/hooks/usePostwithChildPosts.t
 
 export function PostWithComments() {
   const { ref, inView } = useInView();
+  const currentPostRef = useRef<HTMLDivElement>(null);
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
 
   const {
@@ -26,12 +27,27 @@ export function PostWithComments() {
 
   const parentPost = data?.post;
   const ancestors = data?.ancestors ?? [];
+  const isViewingComment = Boolean(parentPost?.parentPostId);
 
   useEffect(() => {
     if (inView && hasNextPage) {
       void fetchNextPage();
     }
   }, [inView, hasNextPage, fetchNextPage]);
+
+  useEffect(() => {
+    if (!parentPost) return;
+
+    requestAnimationFrame(() => {
+      const top = currentPostRef.current?.getBoundingClientRect().top;
+      if (top == null) return;
+
+      window.scrollBy({
+        top: top - 72,
+        behavior: 'auto',
+      });
+    });
+  }, [parentPost?.id]);
 
   if (isParentLoading) {
     return <Loading />;
@@ -50,19 +66,15 @@ export function PostWithComments() {
             post={ancestors[ancestors.length - 1]}
             hideDivider
             replaceOnClick
+            withLine
           />
-          <Divider mx={-16} mt="md" />
         </Box>
       )}
 
       {/* Render Current Post */}
       {parentPost && (
-        <Box pt="md" pb="md">
-          <PostItem
-            post={parentPost}
-            hideDivider
-            clickTarget={null}
-          />
+        <Box ref={currentPostRef} pt="md" pb="md">
+          <PostItem post={parentPost} hideDivider clickTarget={null} />
         </Box>
       )}
 
@@ -97,6 +109,8 @@ export function PostWithComments() {
 
       {/* Error Handling for Child Posts */}
       {isChildError && <div>Error loading child posts</div>}
+
+      {isViewingComment && <Box h="calc(100vh - 120px)" />}
     </Stack>
   );
 }

--- a/client/src/features/posts/components/CreatePost/CreatePost.module.css
+++ b/client/src/features/posts/components/CreatePost/CreatePost.module.css
@@ -54,5 +54,33 @@
 }
 
 .inlineContainer {
-  padding: 16px 0;
+  padding: 12px 0;
+}
+
+.inlineReplyPill {
+  min-height: 54px;
+  padding: 8px 10px;
+  border: 1px solid var(--mantine-color-gray-3);
+  border-radius: 999px;
+  background: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-6));
+}
+
+.inlineReplyInput {
+  flex: 1;
+  min-width: 0;
+}
+
+.inlineReplyInput textarea {
+  padding: 6px 0;
+  font-size: 1rem;
+  line-height: 1.35;
+  min-height: 32px;
+}
+
+.inlineReplyInput textarea::placeholder {
+  color: var(--mantine-color-gray-6);
+}
+
+.inlineReplyButton {
+  font-weight: 700;
 }

--- a/client/src/features/posts/components/CreatePost/CreatePost.tsx
+++ b/client/src/features/posts/components/CreatePost/CreatePost.tsx
@@ -121,6 +121,133 @@ export function CreatePost({ parentPost, editingPost, inline, onClose }: CreateP
 
   const isReply = !!parentPost;
 
+  if (inline && isReply && !isEditing) {
+    return (
+      <Stack gap={8} className={classes.inlineContainer}>
+        <Flex gap={10} align="center" className={classes.inlineReplyPill}>
+          <UserPic
+            username={userData?.username ?? ''}
+            avatar={userData?.profilePic ?? ''}
+            size="sm"
+          />
+          <Textarea
+            autosize
+            minRows={1}
+            maxRows={3}
+            placeholder={`Reply to ${parentPost.postedBy.username}...`}
+            className={classes.inlineReplyInput}
+            variant="unstyled"
+            value={text}
+            onChange={(e) => setText(e.currentTarget.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                if ((text.trim() || images.length > 0) && !isPending) {
+                  void handleSubmit();
+                }
+              }
+            }}
+          />
+          <Popover
+            opened={imagePopoverOpen}
+            onChange={setImagePopoverOpen}
+            width={300}
+            position="bottom-end"
+            shadow="md"
+            withArrow
+          >
+            <Popover.Target>
+              <ActionIcon
+                variant="subtle"
+                color="gray"
+                size="lg"
+                onClick={() => setImagePopoverOpen((o) => !o)}
+                radius="xl"
+                disabled={images.length >= MAX_IMAGES}
+              >
+                <IconPhoto size={20} />
+              </ActionIcon>
+            </Popover.Target>
+
+            <Popover.Dropdown>
+              <Text size="xs" fw={500} mb={6}>
+                Paste image URL
+              </Text>
+              <Group gap={8}>
+                <TextInput
+                  placeholder="https://example.com/image.jpg"
+                  size="xs"
+                  style={{ flex: 1 }}
+                  value={imageUrl}
+                  onChange={(e) => setImageUrl(e.currentTarget.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      addImageUrl();
+                    }
+                  }}
+                  autoFocus
+                />
+                <ActionIcon
+                  size="sm"
+                  radius="xl"
+                  onClick={addImageUrl}
+                  variant="filled"
+                  disabled={!imageUrl.trim()}
+                >
+                  <IconPlus size={16} />
+                </ActionIcon>
+              </Group>
+            </Popover.Dropdown>
+          </Popover>
+          <Button
+            className={classes.inlineReplyButton}
+            onClick={handleSubmit}
+            loading={isPending}
+            disabled={(!text.trim() && images.length === 0) || isPending}
+            radius="xl"
+            size="xs"
+          >
+            Reply
+          </Button>
+        </Flex>
+
+        {images.length > 0 && (
+          <SimpleGrid cols={images.length === 1 ? 1 : 2} spacing="xs">
+            {images.map((url) => (
+              <Box key={url} pos="relative">
+                <Image
+                  src={url}
+                  alt="attachment"
+                  radius="md"
+                  h={images.length === 1 ? 220 : 140}
+                  fit="cover"
+                  fallbackSrc="https://placehold.co/400x300?text=Invalid+URL"
+                />
+                <CloseButton
+                  size="sm"
+                  variant="filled"
+                  pos="absolute"
+                  top={6}
+                  right={6}
+                  onClick={() => removeImage(url)}
+                  aria-label="Remove image"
+                  className={classes.removeImageIcon}
+                />
+              </Box>
+            ))}
+          </SimpleGrid>
+        )}
+
+        {error && (
+          <Text c="red" size="sm" px="xs">
+            {error}
+          </Text>
+        )}
+      </Stack>
+    );
+  }
+
   return (
     <Stack gap={0} className={inline ? classes.inlineContainer : ''}>
       {isReply && !inline && (


### PR DESCRIPTION
## Summary

Updates the post detail and comment thread UI to feel closer to Threads, with a more compact reply composer and clearer visual hierarchy between a post, its parent context, and its replies.

## Changes

- Replaces the large inline reply form with a compact pill-style reply box.
- Keeps the reply placeholder centered and reduces the vertical space used by the composer.
- Adds avatar connector lines between parent and child posts where they help show thread context.
- Removes the horizontal divider between a parent post and the focused comment/post.
- Prevents the currently opened post/comment from drawing a connector line down into the reply box.
- When opening a comment, scrolls the focused comment near the top of the page while still allowing the parent post to be visible by scrolling up.
- Adds bottom spacing on focused comment views so the selected comment can stay near the top even when there are few replies.

## Verification

- `./node_modules/.bin/tsc -b`
- `./node_modules/.bin/vite build`