### PR TITLE
feat: add Redis-backed API rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A full-stack social media platform that started as a synchronous CRUD app and wa
 - **Correctness at the source of truth:** denormalized counters maintained in **transactions**, idempotent via unique constraints.
 - **Stateless, horizontally scalable API** behind a Caddy load balancer with health checks and graceful shutdown.
 - **Redis-backed auth:** refresh-token rotation, reuse detection, and lookup-free request validation.
+- **Redis-backed API rate limits** split by route risk: auth, writes, search, and general traffic.
 - **Tested at the seams** with Vitest + Testcontainers (Postgres, Redis, Kafka, Elasticsearch) and gated by CI.
 
 ## Table of Contents
@@ -79,6 +80,9 @@ Denormalized counters (likes, reposts, followers, comments) are updated **togeth
 ### Authentication
 JWT access/refresh auth with **refresh-token rotation and reuse detection** (a replayed, retired token revokes the session), backed by a **Redis session store** with log-out-everywhere. Per-request authorization validates the signed access token **without a database lookup**; revocation happens at the refresh boundary.
 
+### Rate limiting
+API rate limits are backed by **Redis**, so the counters work across multiple stateless server replicas instead of only inside one Node process. Limits are split by endpoint risk: stricter limits for signup/login/refresh, moderate limits for write actions, a separate search budget, and a loose general API fallback. When Redis is unavailable, the limiter fails open and logs the skipped check so normal traffic is not locked out by protective infrastructure.
+
 ### Horizontal scalability
 The API holds no per-request state in process memory (sessions live in Redis), so it runs as **identical stateless replicas** behind a Caddy load balancer, no sticky sessions needed. A `/api/v1/health` liveness probe and graceful `SIGTERM` draining let replicas be added or removed without dropping in-flight requests.
 
@@ -125,7 +129,7 @@ A deliberate cost decision on a small VPS: the correctness-critical pieces run i
 | Runs in production | Built and run locally (with a production-safe fallback) |
 |---|---|
 | Core API, posts, interactions, profiles | Kafka (Redpanda) event backbone + outbox + notifications consumer |
-| Redis-backed auth (rotation, reuse detection, sessions) | Feed fan-out on write (prod serves the read-time feed) |
+| Redis-backed auth and API rate limits | Feed fan-out on write (prod serves the read-time feed) |
 | Transactional counters | Elasticsearch + CDC search index (prod serves Postgres full-text) |
 | Postgres full-text search | Multi-replica load-balancing demo (prod runs a single replica) |
 | Stateless API, CI/CD, AWS EC2 deploy | |
@@ -142,7 +146,7 @@ Integration tests run against **real dependencies via Testcontainers**, because 
 
 - Vitest + Supertest against the real Express app.
 - Testcontainers spins up Postgres, Redis, Kafka (Redpanda), and Elasticsearch.
-- Coverage targets the signature risk of each feature: refresh-token reuse detection, counter consistency under concurrency, consumer idempotency on redelivery, feed fan-out correctness (and the celebrity merge), and search ranking / index sync.
+- Coverage targets the signature risk of each feature: refresh-token reuse detection, Redis-backed rate-limit enforcement and fail-open behavior, counter consistency under concurrency, consumer idempotency on redelivery, feed fan-out correctness (and the celebrity merge), and search ranking / index sync.
 - GitHub Actions runs the suite and gates build + deploy.
 
 ---

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@eslint/js':
+        specifier: ^9.39.4
+        version: 9.39.4
       '@testcontainers/elasticsearch':
         specifier: ^12.0.1
         version: 12.0.1
@@ -238,6 +241,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      typescript-eslint:
+        specifier: ^8.60.1
+        version: 8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(vite@8.0.16(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.22.4)(yaml@2.9.0))

--- a/server/eslint.config.js
+++ b/server/eslint.config.js
@@ -4,7 +4,7 @@ import tseslint from 'typescript-eslint';
 import js from '@eslint/js';
 
 export default tseslint.config(
-  { ignores: ['dist', '**/*.d.ts', '*.config.*'] },
+  { ignores: ['dist', 'generated', '**/*.d.ts', '*.config.*'] },
   {
     extends: [
       js.configs.recommended,
@@ -16,7 +16,7 @@ export default tseslint.config(
       ecmaVersion: 2020,
       globals: globals.node,
       parserOptions: {
-        project: ['./tsconfig.json', './tsconfig.node.json'],
+        project: ['./tsconfig.json'],
         tsconfigRootDir: import.meta.dirname,
       },
     },
@@ -31,6 +31,18 @@ export default tseslint.config(
           },
         },
       ],
+    },
+  },
+  {
+    files: ['test/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-empty-function': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+      '@typescript-eslint/prefer-nullish-coalescing': 'off',
     },
   },
 );

--- a/server/package.json
+++ b/server/package.json
@@ -32,6 +32,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@eslint/js": "^9.39.4",
     "@testcontainers/elasticsearch": "^12.0.1",
     "@testcontainers/postgresql": "^12.0.1",
     "@testcontainers/redpanda": "^12.0.1",
@@ -50,6 +51,7 @@
     "tsdown": "0.21.0-beta.2",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3",
+    "typescript-eslint": "^8.60.1",
     "vitest": "^4.1.8"
   }
 }

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -8,8 +8,11 @@ import { notificationRouter } from './routes/notificationRoutes.js';
 import { postRouter } from './routes/postRoutes.js';
 import { userRouter } from './routes/userRoutes.js';
 import { searchRouter } from './routes/searchRoutes.js';
+import { generalApiRateLimit } from './middlewares/rateLimit.js';
 
 export const app: Express = express();
+
+app.set('trust proxy', 1);
 
 // Liveness probe for the load balancer's health checks. Deliberately does NOT
 // touch Postgres or Redis: it answers "is this process up and accepting HTTP?"
@@ -26,6 +29,7 @@ app.use(express.urlencoded({ extended: true }));
 app.use(cookieParser());
 
 // Routes
+app.use('/api/v1', generalApiRateLimit);
 app.use('/api/v1/users', userRouter);
 app.use('/api/v1/posts', postRouter);
 app.use('/api/v1/auth', authRouter);

--- a/server/src/bench/run.ts
+++ b/server/src/bench/run.ts
@@ -47,8 +47,10 @@ async function main() {
 
   // The app reads these at import; set them before importing app/db.
   process.env.DATABASE_URL = benchUrl;
-  process.env.ACCESS_TOKEN_SECRET ||= 'bench-access-secret';
-  process.env.REFRESH_TOKEN_SECRET ||= 'bench-refresh-secret';
+  const accessTokenSecret =
+    process.env.ACCESS_TOKEN_SECRET ?? 'bench-access-secret';
+  process.env.ACCESS_TOKEN_SECRET = accessTokenSecret;
+  process.env.REFRESH_TOKEN_SECRET ??= 'bench-refresh-secret';
 
   console.log('Applying schema...');
   execSync('npx prisma migrate deploy', {
@@ -85,7 +87,7 @@ async function main() {
       'TRUNCATE TABLE "Like", "Repost", "Save", "UserFollows", "Post", "User" RESTART IDENTITY CASCADE',
     );
     const focalId = await seedDatabase(prisma, counts);
-    const token = jwt.sign({ userId: focalId }, process.env.ACCESS_TOKEN_SECRET!, {
+    const token = jwt.sign({ userId: focalId }, accessTokenSecret, {
       expiresIn: '1h',
     });
     const auth = { Authorization: `Bearer ${token}` };

--- a/server/src/errors/errors.ts
+++ b/server/src/errors/errors.ts
@@ -1,4 +1,4 @@
-import { HttpStatusCode } from '@/constants/constant.js';
+import { HttpStatusCode } from '../constants/constant.js';
 
 export class JWTError extends Error {
   constructor(message: string) {

--- a/server/src/events/consumer.ts
+++ b/server/src/events/consumer.ts
@@ -20,11 +20,11 @@ import { TOPIC, kafka } from './kafka.js';
 export const consumer: Consumer = kafka.consumer({ groupId: 'notifications' });
 
 // The shape the publisher writes to each message value.
-interface OutboxMessage {
+type OutboxMessage = {
   id: string;
   eventType: string;
   payload: unknown;
-}
+};
 
 // Turn one event into a notification, idempotently. Exported so tests can drive
 // it directly without standing up a running consumer.

--- a/server/src/events/events.ts
+++ b/server/src/events/events.ts
@@ -12,23 +12,23 @@ export type EventType =
   | typeof POST_CREATED;
 
 // Someone liked recipient's post.
-export interface LikeCreatedPayload {
+export type LikeCreatedPayload = {
   actorId: number;
   recipientId: number;
   postId: number;
-}
+};
 
 // Someone followed recipient.
-export interface FollowCreatedPayload {
+export type FollowCreatedPayload = {
   actorId: number;
   recipientId: number;
-}
+};
 
 // A root post was created; drives feed fan-out.
-export interface PostCreatedPayload {
+export type PostCreatedPayload = {
   postId: number;
   authorId: number;
-}
+};
 
 export type EventPayload =
   | LikeCreatedPayload

--- a/server/src/middlewares/rateLimit.ts
+++ b/server/src/middlewares/rateLimit.ts
@@ -24,7 +24,7 @@ function defaultKey(req: Request): string {
     return `user:${req.user.id}`;
   }
 
-  return `ip:${req.ip || req.socket.remoteAddress || 'unknown'}`;
+  return `ip:${req.ip ?? req.socket.remoteAddress ?? 'unknown'}`;
 }
 
 export function createRateLimit({

--- a/server/src/middlewares/rateLimit.ts
+++ b/server/src/middlewares/rateLimit.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express';
 
-import { redis } from '@/db/redis';
+import { redis } from '../db/redis.js';
 
 type RateLimitOptions = {
   name: string;

--- a/server/src/middlewares/rateLimit.ts
+++ b/server/src/middlewares/rateLimit.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express';
 
-import { redis } from '../db/redis.js';
+import { redis } from '@/db/redis';
 
 type RateLimitOptions = {
   name: string;

--- a/server/src/middlewares/rateLimit.ts
+++ b/server/src/middlewares/rateLimit.ts
@@ -1,0 +1,97 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express';
+
+import { redis } from '../db/redis.js';
+
+type RateLimitOptions = {
+  name: string;
+  max: number;
+  windowMs: number;
+  key?: (req: Request) => string;
+};
+
+const SECOND_MS = 1000;
+
+function envNumber(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function defaultKey(req: Request): string {
+  if (req.user?.id != null) {
+    return `user:${req.user.id}`;
+  }
+
+  return `ip:${req.ip || req.socket.remoteAddress || 'unknown'}`;
+}
+
+export function createRateLimit({
+  name,
+  max,
+  windowMs,
+  key = defaultKey,
+}: RateLimitOptions): RequestHandler {
+  const windowSeconds = Math.ceil(windowMs / SECOND_MS);
+
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const redisKey = `rate-limit:${name}:${key(req)}`;
+
+    try {
+      const count = await redis.incr(redisKey);
+
+      if (count === 1) {
+        await redis.expire(redisKey, windowSeconds);
+      }
+
+      const ttl = await redis.ttl(redisKey);
+      const resetSeconds = ttl > 0 ? ttl : windowSeconds;
+      const remaining = Math.max(max - count, 0);
+
+      res.setHeader('X-RateLimit-Limit', String(max));
+      res.setHeader('X-RateLimit-Remaining', String(remaining));
+      res.setHeader(
+        'X-RateLimit-Reset',
+        String(Math.ceil(Date.now() / SECOND_MS) + resetSeconds),
+      );
+
+      if (count > max) {
+        res.setHeader('Retry-After', String(resetSeconds));
+        res.status(429).json({
+          message: 'Too many requests, please try again later.',
+        });
+        return;
+      }
+
+      next();
+    } catch (error) {
+      console.error(`Rate limit skipped for ${name}:`, error);
+      next();
+    }
+  };
+}
+
+export const generalApiRateLimit: RequestHandler = createRateLimit({
+  name: 'general',
+  max: envNumber('GENERAL_RATE_LIMIT_MAX', 300),
+  windowMs: envNumber('GENERAL_RATE_LIMIT_WINDOW_MS', 15 * 60 * SECOND_MS),
+});
+
+export const authRateLimit: RequestHandler = createRateLimit({
+  name: 'auth',
+  max: envNumber('AUTH_RATE_LIMIT_MAX', 10),
+  windowMs: envNumber('AUTH_RATE_LIMIT_WINDOW_MS', 10 * 60 * SECOND_MS),
+});
+
+export const writeActionRateLimit: RequestHandler = createRateLimit({
+  name: 'write-action',
+  max: envNumber('WRITE_RATE_LIMIT_MAX', 60),
+  windowMs: envNumber('WRITE_RATE_LIMIT_WINDOW_MS', 60 * SECOND_MS),
+});
+
+export const searchRateLimit: RequestHandler = createRateLimit({
+  name: 'search',
+  max: envNumber('SEARCH_RATE_LIMIT_MAX', 30),
+  windowMs: envNumber('SEARCH_RATE_LIMIT_WINDOW_MS', 60 * SECOND_MS),
+});

--- a/server/src/routes/authRoutes.ts
+++ b/server/src/routes/authRoutes.ts
@@ -6,9 +6,9 @@ import {
   logoutUser,
   refreshAccessToken,
   signupUser,
-} from '@/controllers/authController';
-import { protectRoute } from '@/middlewares/protectRoute';
-import { authRateLimit } from '@/middlewares/rateLimit';
+} from '../controllers/authController.js';
+import { protectRoute } from '../middlewares/protectRoute.js';
+import { authRateLimit } from '../middlewares/rateLimit.js';
 
 export const authRouter: Router = express.Router();
 

--- a/server/src/routes/authRoutes.ts
+++ b/server/src/routes/authRoutes.ts
@@ -8,12 +8,13 @@ import {
   signupUser,
 } from '../controllers/authController.js';
 import { protectRoute } from '../middlewares/protectRoute.js';
+import { authRateLimit } from '../middlewares/rateLimit.js';
 
 export const authRouter: Router = express.Router();
 
 //auth
-authRouter.post('/signup', signupUser);
-authRouter.post('/login', loginUser);
+authRouter.post('/signup', authRateLimit, signupUser);
+authRouter.post('/login', authRateLimit, loginUser);
 authRouter.post('/logout', logoutUser);
 authRouter.post('/logout-all', protectRoute, logoutAllSessions);
-authRouter.get('/refresh-token', refreshAccessToken);
+authRouter.get('/refresh-token', authRateLimit, refreshAccessToken);

--- a/server/src/routes/authRoutes.ts
+++ b/server/src/routes/authRoutes.ts
@@ -6,9 +6,9 @@ import {
   logoutUser,
   refreshAccessToken,
   signupUser,
-} from '../controllers/authController.js';
-import { protectRoute } from '../middlewares/protectRoute.js';
-import { authRateLimit } from '../middlewares/rateLimit.js';
+} from '@/controllers/authController';
+import { protectRoute } from '@/middlewares/protectRoute';
+import { authRateLimit } from '@/middlewares/rateLimit';
 
 export const authRouter: Router = express.Router();
 

--- a/server/src/routes/postRoutes.ts
+++ b/server/src/routes/postRoutes.ts
@@ -1,6 +1,6 @@
 import express, { Router } from 'express';
 
-import { createPost } from '../controllers/postControllers/createPostController.js';
+import { createPost } from '@/controllers/postControllers/createPostController';
 import {
   getFollowingPosts,
   getForYouPosts,
@@ -9,20 +9,20 @@ import {
   getPostById,
   getPostComments,
   getSavedPosts,
-} from '../controllers/postControllers/getPostController.js';
+} from '@/controllers/postControllers/getPostController';
 import {
   getCommentsByUsername,
   getPostsByUsername,
-} from '../controllers/postControllers/getUserPostsController.js';
+} from '@/controllers/postControllers/getUserPostsController';
 import {
   deletePostById,
   likeUnlikePost,
   repostUnrepost,
   saveUnsavePost,
   updatePost,
-} from '../controllers/postControllers/updatePostController.js';
-import { optionalProtectRoute, protectRoute } from '../middlewares/protectRoute.js';
-import { writeActionRateLimit } from '../middlewares/rateLimit.js';
+} from '@/controllers/postControllers/updatePostController';
+import { optionalProtectRoute, protectRoute } from '@/middlewares/protectRoute';
+import { writeActionRateLimit } from '@/middlewares/rateLimit';
 
 export const postRouter: Router = express.Router();
 
@@ -72,5 +72,13 @@ postRouter.put(
 );
 
 // get posts/comments by username
-postRouter.get('/user/:username/posts', optionalProtectRoute, getPostsByUsername);
-postRouter.get('/user/:username/comments', optionalProtectRoute, getCommentsByUsername);
+postRouter.get(
+  '/user/:username/posts',
+  optionalProtectRoute,
+  getPostsByUsername,
+);
+postRouter.get(
+  '/user/:username/comments',
+  optionalProtectRoute,
+  getCommentsByUsername,
+);

--- a/server/src/routes/postRoutes.ts
+++ b/server/src/routes/postRoutes.ts
@@ -1,6 +1,6 @@
 import express, { Router } from 'express';
 
-import { createPost } from '@/controllers/postControllers/createPostController';
+import { createPost } from '../controllers/postControllers/createPostController.js';
 import {
   getFollowingPosts,
   getForYouPosts,
@@ -9,20 +9,20 @@ import {
   getPostById,
   getPostComments,
   getSavedPosts,
-} from '@/controllers/postControllers/getPostController';
+} from '../controllers/postControllers/getPostController.js';
 import {
   getCommentsByUsername,
   getPostsByUsername,
-} from '@/controllers/postControllers/getUserPostsController';
+} from '../controllers/postControllers/getUserPostsController.js';
 import {
   deletePostById,
   likeUnlikePost,
   repostUnrepost,
   saveUnsavePost,
   updatePost,
-} from '@/controllers/postControllers/updatePostController';
-import { optionalProtectRoute, protectRoute } from '@/middlewares/protectRoute';
-import { writeActionRateLimit } from '@/middlewares/rateLimit';
+} from '../controllers/postControllers/updatePostController.js';
+import { optionalProtectRoute, protectRoute } from '../middlewares/protectRoute.js';
+import { writeActionRateLimit } from '../middlewares/rateLimit.js';
 
 export const postRouter: Router = express.Router();
 

--- a/server/src/routes/postRoutes.ts
+++ b/server/src/routes/postRoutes.ts
@@ -22,6 +22,7 @@ import {
   updatePost,
 } from '../controllers/postControllers/updatePostController.js';
 import { optionalProtectRoute, protectRoute } from '../middlewares/protectRoute.js';
+import { writeActionRateLimit } from '../middlewares/rateLimit.js';
 
 export const postRouter: Router = express.Router();
 
@@ -35,15 +36,40 @@ postRouter.get('/saved', protectRoute, getSavedPosts);
 postRouter.get('/:postId/comments', optionalProtectRoute, getPostComments);
 postRouter.get('/:postId', optionalProtectRoute, getPostById);
 
-postRouter.delete('/:postId', protectRoute, deletePostById);
-postRouter.put('/:postId', protectRoute, updatePost);
+postRouter.delete(
+  '/:postId',
+  protectRoute,
+  writeActionRateLimit,
+  deletePostById,
+);
+postRouter.put('/:postId', protectRoute, writeActionRateLimit, updatePost);
 
-postRouter.post('/:parentPostId', protectRoute, createPost); // for create comment under post
-postRouter.post('/', protectRoute, createPost); // for create post
+postRouter.post(
+  '/:parentPostId',
+  protectRoute,
+  writeActionRateLimit,
+  createPost,
+); // for create comment under post
+postRouter.post('/', protectRoute, writeActionRateLimit, createPost); // for create post
 
-postRouter.put('/:postId/like', protectRoute, likeUnlikePost);
-postRouter.put('/:postId/save', protectRoute, saveUnsavePost);
-postRouter.put('/:postId/repost', protectRoute, repostUnrepost);
+postRouter.put(
+  '/:postId/like',
+  protectRoute,
+  writeActionRateLimit,
+  likeUnlikePost,
+);
+postRouter.put(
+  '/:postId/save',
+  protectRoute,
+  writeActionRateLimit,
+  saveUnsavePost,
+);
+postRouter.put(
+  '/:postId/repost',
+  protectRoute,
+  writeActionRateLimit,
+  repostUnrepost,
+);
 
 // get posts/comments by username
 postRouter.get('/user/:username/posts', optionalProtectRoute, getPostsByUsername);

--- a/server/src/routes/searchRoutes.ts
+++ b/server/src/routes/searchRoutes.ts
@@ -1,8 +1,9 @@
 import express, { Router } from 'express';
 import { searchPosts, searchUsers } from '../controllers/searchController.js';
 import { optionalProtectRoute } from '../middlewares/protectRoute.js';
+import { searchRateLimit } from '../middlewares/rateLimit.js';
 
 export const searchRouter: Router = express.Router();
 
-searchRouter.get('/posts', optionalProtectRoute, searchPosts);
-searchRouter.get('/users', optionalProtectRoute, searchUsers);
+searchRouter.get('/posts', optionalProtectRoute, searchRateLimit, searchPosts);
+searchRouter.get('/users', optionalProtectRoute, searchRateLimit, searchUsers);

--- a/server/src/routes/searchRoutes.ts
+++ b/server/src/routes/searchRoutes.ts
@@ -1,8 +1,8 @@
 import express, { Router } from 'express';
 
-import { searchPosts, searchUsers } from '@/controllers/searchController';
-import { optionalProtectRoute } from '@/middlewares/protectRoute';
-import { searchRateLimit } from '@/middlewares/rateLimit';
+import { searchPosts, searchUsers } from '../controllers/searchController.js';
+import { optionalProtectRoute } from '../middlewares/protectRoute.js';
+import { searchRateLimit } from '../middlewares/rateLimit.js';
 
 export const searchRouter: Router = express.Router();
 

--- a/server/src/routes/searchRoutes.ts
+++ b/server/src/routes/searchRoutes.ts
@@ -1,7 +1,8 @@
 import express, { Router } from 'express';
-import { searchPosts, searchUsers } from '../controllers/searchController.js';
-import { optionalProtectRoute } from '../middlewares/protectRoute.js';
-import { searchRateLimit } from '../middlewares/rateLimit.js';
+
+import { searchPosts, searchUsers } from '@/controllers/searchController';
+import { optionalProtectRoute } from '@/middlewares/protectRoute';
+import { searchRateLimit } from '@/middlewares/rateLimit';
 
 export const searchRouter: Router = express.Router();
 

--- a/server/src/routes/userRoutes.ts
+++ b/server/src/routes/userRoutes.ts
@@ -7,11 +7,22 @@ import {
   updateUser,
 } from '../controllers/userController.js';
 import { protectRoute } from '../middlewares/protectRoute.js';
+import { writeActionRateLimit } from '../middlewares/rateLimit.js';
 
 export const userRouter: Router = express.Router();
 
 // user
-userRouter.put('/follow/:id', protectRoute, followUnfollowUser);
-userRouter.put('/me/profile', protectRoute, updateUser);
+userRouter.put(
+  '/follow/:id',
+  protectRoute,
+  writeActionRateLimit,
+  followUnfollowUser,
+);
+userRouter.put(
+  '/me/profile',
+  protectRoute,
+  writeActionRateLimit,
+  updateUser,
+);
 userRouter.get('/me', protectRoute, getMyData);
 userRouter.get('/:username', getUserProfile);

--- a/server/src/routes/userRoutes.ts
+++ b/server/src/routes/userRoutes.ts
@@ -5,9 +5,9 @@ import {
   getMyData,
   getUserProfile,
   updateUser,
-} from '@/controllers/userController';
-import { protectRoute } from '@/middlewares/protectRoute';
-import { writeActionRateLimit } from '@/middlewares/rateLimit';
+} from '../controllers/userController.js';
+import { protectRoute } from '../middlewares/protectRoute.js';
+import { writeActionRateLimit } from '../middlewares/rateLimit.js';
 
 export const userRouter: Router = express.Router();
 

--- a/server/src/routes/userRoutes.ts
+++ b/server/src/routes/userRoutes.ts
@@ -5,9 +5,9 @@ import {
   getMyData,
   getUserProfile,
   updateUser,
-} from '../controllers/userController.js';
-import { protectRoute } from '../middlewares/protectRoute.js';
-import { writeActionRateLimit } from '../middlewares/rateLimit.js';
+} from '@/controllers/userController';
+import { protectRoute } from '@/middlewares/protectRoute';
+import { writeActionRateLimit } from '@/middlewares/rateLimit';
 
 export const userRouter: Router = express.Router();
 
@@ -18,11 +18,6 @@ userRouter.put(
   writeActionRateLimit,
   followUnfollowUser,
 );
-userRouter.put(
-  '/me/profile',
-  protectRoute,
-  writeActionRateLimit,
-  updateUser,
-);
+userRouter.put('/me/profile', protectRoute, writeActionRateLimit, updateUser);
 userRouter.get('/me', protectRoute, getMyData);
 userRouter.get('/:username', getUserProfile);

--- a/server/src/search/esClient.ts
+++ b/server/src/search/esClient.ts
@@ -11,10 +11,9 @@ let client: Client | null = null;
 // Built lazily from env so tests can point it at a Testcontainers node that is
 // started after this module is imported.
 export function getEsClient(): Client {
-  if (!client) {
-    client = new Client({
-      node: process.env.ELASTICSEARCH_URL ?? 'http://localhost:9200',
-    });
-  }
+  client ??= new Client({
+    node: process.env.ELASTICSEARCH_URL ?? 'http://localhost:9200',
+  });
+
   return client;
 }

--- a/server/src/search/postIndex.ts
+++ b/server/src/search/postIndex.ts
@@ -4,13 +4,13 @@ import { getEsClient } from './esClient.js';
 export const POST_INDEX = 'posts';
 
 // The minimal post shape the indexer and reindex need.
-export interface IndexablePost {
+export type IndexablePost = {
   id: number;
   text: string | null;
   postedById: number;
   createdAt: Date | string;
   isDeleted: boolean;
-}
+};
 
 // Create the index with an explicit mapping if it isn't there yet.
 export async function ensurePostIndex(): Promise<void> {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -43,7 +43,7 @@ if (process.env.KAFKA_BROKERS) {
 // connection refuses to drain.
 let shuttingDown = false;
 
-async function shutdown(signal: string): Promise<void> {
+function shutdown(signal: string): void {
   if (shuttingDown) return;
   shuttingDown = true;
   console.log(`${signal} received, shutting down gracefully...`);
@@ -68,5 +68,5 @@ async function shutdown(signal: string): Promise<void> {
   });
 }
 
-process.on('SIGTERM', () => void shutdown('SIGTERM'));
-process.on('SIGINT', () => void shutdown('SIGINT'));
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));

--- a/server/test/rateLimit.test.ts
+++ b/server/test/rateLimit.test.ts
@@ -2,9 +2,10 @@ import express, { NextFunction, Request, Response } from 'express';
 import request from 'supertest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { app } from '../src/app';
-import { redis } from '../src/db/redis';
-import { createRateLimit } from '../src/middlewares/rateLimit';
+import { app } from '@/app';
+import { redis } from '@/db/redis';
+import { createRateLimit } from '@/middlewares/rateLimit';
+
 import { signup, validUser } from './helpers';
 import { resetDatabase } from './setup/resetDb';
 
@@ -59,7 +60,9 @@ describe('rate limits', () => {
 
     expect(third.status).toBe(429);
     expect(third.headers['retry-after']).toBeDefined();
-    expect(third.body.message).toBe('Too many requests, please try again later.');
+    expect(third.body.message).toBe(
+      'Too many requests, please try again later.',
+    );
   });
 
   it('uses the authenticated user id when one is available', async () => {
@@ -85,7 +88,9 @@ describe('rate limits', () => {
   });
 
   it('fails open when Redis is unavailable', async () => {
-    vi.spyOn(redis, 'incr').mockRejectedValueOnce(new Error('redis unavailable'));
+    vi.spyOn(redis, 'incr').mockRejectedValueOnce(
+      new Error('redis unavailable'),
+    );
 
     const res = await request(testApp()).get('/limited');
 

--- a/server/test/rateLimit.test.ts
+++ b/server/test/rateLimit.test.ts
@@ -1,0 +1,120 @@
+import express, { NextFunction, Request, Response } from 'express';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { app } from '../src/app';
+import { redis } from '../src/db/redis';
+import { createRateLimit } from '../src/middlewares/rateLimit';
+import { signup, validUser } from './helpers';
+import { resetDatabase } from './setup/resetDb';
+
+function testApp() {
+  const limitedApp = express();
+
+  limitedApp.use((req: Request, _res: Response, next: NextFunction) => {
+    const userId = req.header('x-user-id');
+    if (userId) {
+      req.user = { id: Number(userId) };
+    }
+    next();
+  });
+
+  limitedApp.get(
+    '/limited',
+    createRateLimit({
+      name: 'test',
+      max: 2,
+      windowMs: 60_000,
+    }),
+    (_req, res) => {
+      res.status(200).json({ ok: true });
+    },
+  );
+
+  return limitedApp;
+}
+
+describe('rate limits', () => {
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns 429 after the request budget is used', async () => {
+    const limitedApp = testApp();
+
+    const first = await request(limitedApp).get('/limited');
+    const second = await request(limitedApp).get('/limited');
+    const third = await request(limitedApp).get('/limited');
+
+    expect(first.status).toBe(200);
+    expect(first.headers['x-ratelimit-limit']).toBe('2');
+    expect(first.headers['x-ratelimit-remaining']).toBe('1');
+
+    expect(second.status).toBe(200);
+    expect(second.headers['x-ratelimit-remaining']).toBe('0');
+
+    expect(third.status).toBe(429);
+    expect(third.headers['retry-after']).toBeDefined();
+    expect(third.body.message).toBe('Too many requests, please try again later.');
+  });
+
+  it('uses the authenticated user id when one is available', async () => {
+    const limitedApp = testApp();
+
+    const firstUserFirst = await request(limitedApp)
+      .get('/limited')
+      .set('x-user-id', '1');
+    const firstUserSecond = await request(limitedApp)
+      .get('/limited')
+      .set('x-user-id', '1');
+    const firstUserThird = await request(limitedApp)
+      .get('/limited')
+      .set('x-user-id', '1');
+    const secondUserFirst = await request(limitedApp)
+      .get('/limited')
+      .set('x-user-id', '2');
+
+    expect(firstUserFirst.status).toBe(200);
+    expect(firstUserSecond.status).toBe(200);
+    expect(firstUserThird.status).toBe(429);
+    expect(secondUserFirst.status).toBe(200);
+  });
+
+  it('fails open when Redis is unavailable', async () => {
+    vi.spyOn(redis, 'incr').mockRejectedValueOnce(new Error('redis unavailable'));
+
+    const res = await request(testApp()).get('/limited');
+
+    expect(res.status).toBe(200);
+  });
+
+  it('applies the auth limit to the real auth routes', async () => {
+    await signup();
+
+    for (let i = 0; i < 9; i += 1) {
+      const res = await request(app)
+        .post('/api/v1/auth/signup')
+        .send({
+          ...validUser,
+          username: `rate-limit-${i}`,
+          email: `rate-limit-${i}@example.com`,
+        });
+
+      expect(res.status).toBe(201);
+    }
+
+    const limited = await request(app)
+      .post('/api/v1/auth/signup')
+      .send({
+        ...validUser,
+        username: 'rate-limit-blocked',
+        email: 'rate-limit-blocked@example.com',
+      });
+
+    expect(limited.status).toBe(429);
+  });
+});

--- a/server/test/rateLimit.test.ts
+++ b/server/test/rateLimit.test.ts
@@ -2,9 +2,9 @@ import express, { NextFunction, Request, Response } from 'express';
 import request from 'supertest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { app } from '@/app';
-import { redis } from '@/db/redis';
-import { createRateLimit } from '@/middlewares/rateLimit';
+import { app } from '../src/app';
+import { redis } from '../src/db/redis';
+import { createRateLimit } from '../src/middlewares/rateLimit';
 
 import { signup, validUser } from './helpers';
 import { resetDatabase } from './setup/resetDb';


### PR DESCRIPTION
## Summary

Adds Redis-backed rate limiting to protect the API from brute force auth attempts, write spam, expensive search bursts, and abnormal general traffic.

## Changes

- Adds a reusable Redis-backed rate-limit middleware.
- Applies a loose general limit across `/api/v1`.
- Applies stricter limits to signup, login, and refresh-token routes.
- Applies write-action limits to posts, comments, likes, saves, reposts, follows, and profile updates.
- Applies a separate limit to search routes.
- Uses authenticated user id as the rate-limit key when available, falling back to IP for anonymous traffic.
- Sets Express `trust proxy` so IP-based limits work correctly behind Caddy/load balancers.
- Fails open when Redis is unavailable so protective infrastructure does not lock out normal users.
- Adds tests for limit enforcement, authenticated user keying, fail-open behavior, and real auth route wiring.
- Updates the README to document rate limiting.

## Verification

- `npx --yes pnpm@10.34.1 --filter server exec tsc --noEmit`
- `npx --yes pnpm@10.34.1 --filter server build`
- `npx --yes pnpm@10.34.1 --filter server test`