### PR TITLE
feat: link auth pages back home

### DIFF
--- a/client/src/features/auth/components/Login/Login.tsx
+++ b/client/src/features/auth/components/Login/Login.tsx
@@ -1,5 +1,5 @@
 import { useForm } from 'react-hook-form';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { LoginSchema, LoginType } from 'validation';
 
 import { FormError } from '@/components/FormError/FormError.tsx';
@@ -39,7 +39,17 @@ export function Login() {
   return (
     <>
       <Title ta="center" p={15} size="h1">
-        Welcome To Relates!
+        Welcome To{' '}
+        <Anchor
+          component={Link}
+          to="/"
+          c="my-green"
+          inherit
+          aria-label="Go to Relates home page"
+        >
+          Relates
+        </Anchor>
+        !
       </Title>
       <Text c="dimmed" size="sm" ta="center">
         Do not have an account yet?{' '}

--- a/client/src/features/auth/components/Signup/Signup.tsx
+++ b/client/src/features/auth/components/Signup/Signup.tsx
@@ -1,5 +1,5 @@
 import { useForm } from 'react-hook-form';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 import { FormError } from '@/components/FormError/FormError.tsx';
 import { SignupSchema } from '@/types/schemas.ts';
@@ -38,7 +38,17 @@ export function Signup() {
   return (
     <>
       <Title ta="center" size="h1" p={15}>
-        Create Your Account
+        Create Your{' '}
+        <Anchor
+          component={Link}
+          to="/"
+          c="my-green"
+          inherit
+          aria-label="Go to Relates home page"
+        >
+          Relates
+        </Anchor>{' '}
+        Account
       </Title>
       <Text c="dimmed" size="sm" ta="center">
         Already have an account?{' '}


### PR DESCRIPTION
## Summary

Adds a clear way to return from the login and signup pages back to the main Relates page.

## Changes

- Makes the `Relates` word in the login title link to `/`.
- Updates the signup title to include the same linked `Relates` word.
- Uses the app’s green theme color for the home link.

## Verification

- `npx --yes pnpm@10.34.1 --filter client exec tsc -b`
- `npx --yes pnpm@10.34.1 --filter client build`