### PR TITLE
feat: improve For You feed ranking

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A full-stack social media platform that started as a synchronous CRUD app and wa
 
 - **Event backbone:** a transactional **outbox** publishes domain events to **Kafka**; **idempotent consumers** build derived state, with at-least-once delivery handled honestly.
 - **Feed fan-out on write** into per-follower **Redis** sorted sets, including the **celebrity/hot-key hybrid** and a read-time fallback.
+- **For You recommendations** use candidate generation plus score-based ranking across social graph, social proof, engagement, affinity, and freshness signals.
 - **Search index kept in sync via CDC** (Debezium reading the Postgres WAL) into **Elasticsearch**, plus relevance-ranked Postgres full-text search benchmarked **sub-millisecond at 1M posts**.
 - **Correctness at the source of truth:** denormalized counters maintained in **transactions**, idempotent via unique constraints.
 - **Stateless, horizontally scalable API** behind a Caddy load balancer with health checks and graceful shutdown.
@@ -70,6 +71,9 @@ On a like or follow, the event is written to an **outbox table in the same trans
 A new post emits a `POST_CREATED` event; a fan-out consumer writes the post id into each follower's feed, a **Redis sorted set** scored by post id (chronological order plus cursor-friendly paging). The home feed becomes a fast cache read instead of a query across everyone you follow.
 - **Celebrity / hot-key hybrid:** authors above a follower threshold are not fanned out (write amplification); their posts are merged in at read time instead.
 - **Resilience:** a cold feed is rebuilt from Postgres on demand; if Redis is unavailable, serving falls back to the read-time query (and that fallback fails fast so a Redis blip can't hang requests).
+
+### For You recommendations
+The For You feed is a lightweight recommendation pipeline, not a single hard-coded query. It first generates candidates from several sources: the viewer's own posts, followed authors, posts liked/reposted by followed users, authors the viewer has interacted with before, high-engagement posts, and recent public posts for cold start. It then ranks candidates with a score that combines source strength, likes/reposts/comments, and freshness. Pagination uses an opaque score cursor so scrolling remains stable even though the feed is ranked by score rather than simple post id.
 
 ### Search: Postgres full-text + CDC to Elasticsearch
 Post search uses a generated **`tsvector`** column with a GIN index, matched with `websearch_to_tsquery` and ranked by **`ts_rank`** so a strong match outranks an incidental mention. An **Elasticsearch** index is kept in sync through **Change Data Capture**: Debezium reads the Postgres WAL and streams row changes to a consumer that updates the index, eliminating the dual-write problem. Search prefers Elasticsearch when configured and falls back to Postgres full-text otherwise.
@@ -146,7 +150,7 @@ Integration tests run against **real dependencies via Testcontainers**, because 
 
 - Vitest + Supertest against the real Express app.
 - Testcontainers spins up Postgres, Redis, Kafka (Redpanda), and Elasticsearch.
-- Coverage targets the signature risk of each feature: refresh-token reuse detection, Redis-backed rate-limit enforcement and fail-open behavior, counter consistency under concurrency, consumer idempotency on redelivery, feed fan-out correctness (and the celebrity merge), and search ranking / index sync.
+- Coverage targets the signature risk of each feature: refresh-token reuse detection, Redis-backed rate-limit enforcement and fail-open behavior, counter consistency under concurrency, consumer idempotency on redelivery, feed fan-out correctness (and the celebrity merge), For You ranking/cursor behavior, and search ranking / index sync.
 - GitHub Actions runs the suite and gates build + deploy.
 
 ---

--- a/client/src/features/posts/hooks/usePostList.ts
+++ b/client/src/features/posts/hooks/usePostList.ts
@@ -3,12 +3,14 @@ import { PostType } from 'validation';
 
 import { axiosInstance } from '@/api/axiosConfig.ts';
 import { useAuthStore } from '@/stores/authStore.ts';
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { InfiniteData, useInfiniteQuery } from '@tanstack/react-query';
 
 type PostsResponse = {
   posts: Post[];
-  nextCursor: number | null;
+  nextCursor: number | string | null;
 };
+
+type PostListCursor = number | string;
 
 export type Post = PostType & {
   postedBy: {
@@ -33,7 +35,13 @@ export function usePostsList(endpoint = location.pathname) {
   const location = useLocation();
 
   const { data, isPending, isError, hasNextPage, fetchNextPage } =
-    useInfiniteQuery({
+    useInfiniteQuery<
+      PostsResponse,
+      Error,
+      InfiniteData<PostsResponse>,
+      (string | boolean)[],
+      PostListCursor
+    >({
       queryKey: ['posts', isAuthenticated, location.pathname, endpoint],
       queryFn: async ({ pageParam }): Promise<PostsResponse> => {
         let fetchUrl = '';

--- a/client/src/features/user/hooks/useFollowMutation.ts
+++ b/client/src/features/user/hooks/useFollowMutation.ts
@@ -1,5 +1,36 @@
 import { axiosInstance } from '@/api/axiosConfig.ts';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  InfiniteData,
+  QueryKey,
+  useMutation,
+  useQueryClient,
+} from '@tanstack/react-query';
+
+type FollowableUser = {
+  id: number;
+  isFollowing: boolean;
+  followersCount?: number;
+};
+
+type SearchUsersPage = {
+  users?: FollowableUser[];
+  nextCursor: number | null;
+};
+
+function updateFollowableUser<T extends FollowableUser>(
+  user: T,
+  targetUserId: number,
+): T {
+  if (user.id !== targetUserId) return user;
+
+  const isFollowing = !user.isFollowing;
+  const followersCount =
+    user.followersCount == null
+      ? user.followersCount
+      : user.followersCount + (isFollowing ? 1 : -1);
+
+  return { ...user, isFollowing, followersCount };
+}
 
 export function useFollowMutation() {
   const queryClient = useQueryClient();
@@ -11,12 +42,34 @@ export function useFollowMutation() {
       );
       return data;
     },
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['userProfile'] });
-      void queryClient.invalidateQueries({ queryKey: ['posts'] });
+    onSuccess: (_data, userId) => {
+      for (const query of queryClient.getQueriesData<FollowableUser>({
+        queryKey: ['userProfile'],
+      })) {
+        const [queryKey, user] = query;
+        if (!user) continue;
+        queryClient.setQueryData(queryKey, updateFollowableUser(user, userId));
+      }
+
+      for (const query of queryClient.getQueriesData<
+        InfiniteData<SearchUsersPage>
+      >({ queryKey: ['search'] })) {
+        const [queryKey, data] = query as [QueryKey, InfiniteData<SearchUsersPage> | undefined];
+        if (!data) continue;
+
+        queryClient.setQueryData(queryKey, {
+          ...data,
+          pages: data.pages.map((page) => ({
+            ...page,
+            users: page.users?.map((user) =>
+              updateFollowableUser(user, userId),
+            ),
+          })),
+        });
+      }
+
       void queryClient.invalidateQueries({ queryKey: ['parentPost'] });
       void queryClient.invalidateQueries({ queryKey: ['childposts'] });
-      void queryClient.invalidateQueries({ queryKey: ['search'] });
     },
   });
 }

--- a/server/src/controllers/postControllers/getPostController.ts
+++ b/server/src/controllers/postControllers/getPostController.ts
@@ -159,6 +159,29 @@ type ForYouCursor = {
   id: number;
 };
 
+const FOR_YOU_RECENT_CANDIDATE_FLOOR = 200;
+const FOR_YOU_RECENT_CANDIDATE_MULTIPLIER = 20;
+const FOR_YOU_POPULAR_LIKES_THRESHOLD = 5;
+const FOR_YOU_POPULAR_REPOSTS_THRESHOLD = 2;
+const FOR_YOU_POPULAR_COMMENTS_THRESHOLD = 3;
+
+const FOR_YOU_SCORE_OWN_POST = 75;
+const FOR_YOU_SCORE_FOLLOWED_AUTHOR = 70;
+const FOR_YOU_SCORE_REPOSTED_BY_FOLLOWED = 50;
+const FOR_YOU_SCORE_LIKED_BY_FOLLOWED = 45;
+const FOR_YOU_SCORE_AFFINITY_AUTHOR = 35;
+const FOR_YOU_SCORE_POPULAR = 25;
+const FOR_YOU_SCORE_RECENT = 15;
+
+const FOR_YOU_MAX_LIKE_BOOST = 25;
+const FOR_YOU_LIKE_BOOST_WEIGHT = 6;
+const FOR_YOU_MAX_REPOST_BOOST = 18;
+const FOR_YOU_REPOST_BOOST_WEIGHT = 7;
+const FOR_YOU_MAX_COMMENT_BOOST = 16;
+const FOR_YOU_COMMENT_BOOST_WEIGHT = 5;
+const FOR_YOU_MAX_RECENCY_BOOST = 20;
+const FOR_YOU_RECENCY_ID_WEIGHT = 0.001;
+
 function encodeForYouCursor(cursor: ForYouCursor): string {
   return Buffer.from(JSON.stringify(cursor)).toString('base64url');
 }
@@ -191,6 +214,10 @@ async function rankedForYouPostIds(
   limit: number,
 ): Promise<{ rows: RankedPostRow[] }> {
   const decodedCursor = decodeForYouCursor(cursor);
+  const recentCandidateLimit = Math.max(
+    limit * FOR_YOU_RECENT_CANDIDATE_MULTIPLIER,
+    FOR_YOU_RECENT_CANDIDATE_FLOOR,
+  );
   const rankedCursorFilter = decodedCursor
     ? Prisma.sql`
         WHERE (
@@ -227,7 +254,7 @@ async function rankedForYouPostIds(
       WHERE comments."postedById" = ${currentUserId}
     ),
     candidates AS (
-      SELECT p.id, 75.0 AS source_score
+      SELECT p.id, ${FOR_YOU_SCORE_OWN_POST}::double precision AS source_score
       FROM "Post" p
       WHERE p."postedById" = ${currentUserId}
         AND p."parentPostId" IS NULL
@@ -235,7 +262,7 @@ async function rankedForYouPostIds(
 
       UNION ALL
 
-      SELECT p.id, 70.0 AS source_score
+      SELECT p.id, ${FOR_YOU_SCORE_FOLLOWED_AUTHOR}::double precision AS source_score
       FROM "Post" p
       JOIN followed f ON f.user_id = p."postedById"
       WHERE p."parentPostId" IS NULL
@@ -243,7 +270,7 @@ async function rankedForYouPostIds(
 
       UNION ALL
 
-      SELECT p.id, 50.0 AS source_score
+      SELECT p.id, ${FOR_YOU_SCORE_REPOSTED_BY_FOLLOWED}::double precision AS source_score
       FROM "Post" p
       JOIN "Repost" r ON r."postId" = p.id
       JOIN followed f ON f.user_id = r."userId"
@@ -252,7 +279,7 @@ async function rankedForYouPostIds(
 
       UNION ALL
 
-      SELECT p.id, 45.0 AS source_score
+      SELECT p.id, ${FOR_YOU_SCORE_LIKED_BY_FOLLOWED}::double precision AS source_score
       FROM "Post" p
       JOIN "Like" l ON l."postId" = p.id
       JOIN followed f ON f.user_id = l."userId"
@@ -261,7 +288,7 @@ async function rankedForYouPostIds(
 
       UNION ALL
 
-      SELECT p.id, 35.0 AS source_score
+      SELECT p.id, ${FOR_YOU_SCORE_AFFINITY_AUTHOR}::double precision AS source_score
       FROM "Post" p
       JOIN affinity_authors a ON a.user_id = p."postedById"
       WHERE p."postedById" <> ${currentUserId}
@@ -270,26 +297,26 @@ async function rankedForYouPostIds(
 
       UNION ALL
 
-      SELECT p.id, 25.0 AS source_score
+      SELECT p.id, ${FOR_YOU_SCORE_POPULAR}::double precision AS source_score
       FROM "Post" p
       WHERE p."parentPostId" IS NULL
         AND p."isDeleted" = false
         AND (
-          p."likesCount" >= 5
-          OR p."repostsCount" >= 2
-          OR p."commentsCount" >= 3
+          p."likesCount" >= ${FOR_YOU_POPULAR_LIKES_THRESHOLD}
+          OR p."repostsCount" >= ${FOR_YOU_POPULAR_REPOSTS_THRESHOLD}
+          OR p."commentsCount" >= ${FOR_YOU_POPULAR_COMMENTS_THRESHOLD}
         )
 
       UNION ALL
 
-      SELECT recent.id, 15.0 AS source_score
+      SELECT recent.id, ${FOR_YOU_SCORE_RECENT}::double precision AS source_score
       FROM (
         SELECT p.id
         FROM "Post" p
         WHERE p."parentPostId" IS NULL
           AND p."isDeleted" = false
         ORDER BY p.id DESC
-        LIMIT ${Math.max(limit * 20, 200)}
+        LIMIT ${recentCandidateLimit}
       ) recent
     ),
     scored AS (
@@ -297,10 +324,22 @@ async function rankedForYouPostIds(
         p.id,
         (
           MAX(c.source_score)
-          + LEAST(25.0, LN(1 + p."likesCount") * 6)
-          + LEAST(18.0, LN(1 + p."repostsCount") * 7)
-          + LEAST(16.0, LN(1 + p."commentsCount") * 5)
-          + LEAST(20.0, p.id::double precision * 0.001)
+          + LEAST(
+              ${FOR_YOU_MAX_LIKE_BOOST}::double precision,
+              LN(1 + p."likesCount") * ${FOR_YOU_LIKE_BOOST_WEIGHT}
+            )
+          + LEAST(
+              ${FOR_YOU_MAX_REPOST_BOOST}::double precision,
+              LN(1 + p."repostsCount") * ${FOR_YOU_REPOST_BOOST_WEIGHT}
+            )
+          + LEAST(
+              ${FOR_YOU_MAX_COMMENT_BOOST}::double precision,
+              LN(1 + p."commentsCount") * ${FOR_YOU_COMMENT_BOOST_WEIGHT}
+            )
+          + LEAST(
+              ${FOR_YOU_MAX_RECENCY_BOOST}::double precision,
+              p.id::double precision * ${FOR_YOU_RECENCY_ID_WEIGHT}
+            )
         )::double precision AS score
       FROM candidates c
       JOIN "Post" p ON p.id = c.id

--- a/server/src/controllers/postControllers/getPostController.ts
+++ b/server/src/controllers/postControllers/getPostController.ts
@@ -9,6 +9,7 @@ import {
   rebuildFeed,
 } from '../../feed/feedStore.js';
 import {
+  ForYouPostQuerySchema,
   PostParamsSchema,
   PostQuerySchema,
 } from '../../types/validation/schemas.js';
@@ -85,7 +86,7 @@ export async function getHotPosts(req: Request, res: Response) {
 export async function getForYouPosts(req: Request, res: Response) {
   try {
     const currentUserId = req.user!.id;
-    const input = PostQuerySchema.safeParse(req.query);
+    const input = ForYouPostQuerySchema.safeParse(req.query);
     if (!input.success) {
       res.status(400).json({ message: 'Invalid query params' });
       return;
@@ -93,7 +94,8 @@ export async function getForYouPosts(req: Request, res: Response) {
 
     const { cursor, limit } = input.data;
 
-    const candidateIds = await rankedForYouPostIds(currentUserId, cursor, limit);
+    const rankedPage = await rankedForYouPostIds(currentUserId, cursor, limit);
+    const candidateIds = rankedPage.rows.map((row) => row.id);
 
     const posts = await prisma.post.findMany({
       where: { id: { in: candidateIds }, isDeleted: false },
@@ -135,7 +137,10 @@ export async function getForYouPosts(req: Request, res: Response) {
       likes: undefined,
     }));
 
-    const nextCursor = posts.length > 0 ? posts[posts.length - 1].id : null;
+    const nextCursor =
+      rankedPage.rows.length === limit
+        ? encodeForYouCursor(rankedPage.rows[rankedPage.rows.length - 1])
+        : null;
 
     res.status(200).json({ posts: postsWithIsLiked, nextCursor });
   } catch (error) {
@@ -146,15 +151,53 @@ export async function getForYouPosts(req: Request, res: Response) {
 
 type RankedPostRow = {
   id: number;
+  score: number;
 };
+
+type ForYouCursor = {
+  score: number;
+  id: number;
+};
+
+function encodeForYouCursor(cursor: ForYouCursor): string {
+  return Buffer.from(JSON.stringify(cursor)).toString('base64url');
+}
+
+function decodeForYouCursor(raw: string | undefined): ForYouCursor | null {
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(Buffer.from(raw, 'base64url').toString('utf8')) as
+      | Partial<ForYouCursor>
+      | null;
+
+    if (
+      !parsed ||
+      typeof parsed.score !== 'number' ||
+      typeof parsed.id !== 'number'
+    ) {
+      return null;
+    }
+
+    return { score: parsed.score, id: parsed.id };
+  } catch {
+    return null;
+  }
+}
 
 async function rankedForYouPostIds(
   currentUserId: number,
-  cursor: number | undefined,
+  cursor: string | undefined,
   limit: number,
-): Promise<number[]> {
-  const cursorFilter = cursor
-    ? Prisma.sql`AND p.id < ${cursor}`
+): Promise<{ rows: RankedPostRow[] }> {
+  const decodedCursor = decodeForYouCursor(cursor);
+  const rankedCursorFilter = decodedCursor
+    ? Prisma.sql`
+        WHERE (
+          score < ${decodedCursor.score}
+          OR (score = ${decodedCursor.score} AND id < ${decodedCursor.id})
+        )
+      `
     : Prisma.empty;
 
   const rows = await prisma.$queryRaw<RankedPostRow[]>`
@@ -189,7 +232,6 @@ async function rankedForYouPostIds(
       WHERE p."postedById" = ${currentUserId}
         AND p."parentPostId" IS NULL
         AND p."isDeleted" = false
-        ${cursorFilter}
 
       UNION ALL
 
@@ -198,7 +240,6 @@ async function rankedForYouPostIds(
       JOIN followed f ON f.user_id = p."postedById"
       WHERE p."parentPostId" IS NULL
         AND p."isDeleted" = false
-        ${cursorFilter}
 
       UNION ALL
 
@@ -208,7 +249,6 @@ async function rankedForYouPostIds(
       JOIN followed f ON f.user_id = r."userId"
       WHERE p."parentPostId" IS NULL
         AND p."isDeleted" = false
-        ${cursorFilter}
 
       UNION ALL
 
@@ -218,7 +258,6 @@ async function rankedForYouPostIds(
       JOIN followed f ON f.user_id = l."userId"
       WHERE p."parentPostId" IS NULL
         AND p."isDeleted" = false
-        ${cursorFilter}
 
       UNION ALL
 
@@ -228,7 +267,6 @@ async function rankedForYouPostIds(
       WHERE p."postedById" <> ${currentUserId}
         AND p."parentPostId" IS NULL
         AND p."isDeleted" = false
-        ${cursorFilter}
 
       UNION ALL
 
@@ -241,40 +279,41 @@ async function rankedForYouPostIds(
           OR p."repostsCount" >= 2
           OR p."commentsCount" >= 3
         )
-        ${cursorFilter}
 
       UNION ALL
 
-      SELECT p.id, 15.0 AS source_score
-      FROM "Post" p
-      WHERE p."parentPostId" IS NULL
-        AND p."isDeleted" = false
-        ${cursorFilter}
-      ORDER BY id DESC
-      LIMIT ${limit * 8}
+      SELECT recent.id, 15.0 AS source_score
+      FROM (
+        SELECT p.id
+        FROM "Post" p
+        WHERE p."parentPostId" IS NULL
+          AND p."isDeleted" = false
+        ORDER BY p.id DESC
+        LIMIT ${Math.max(limit * 20, 200)}
+      ) recent
     ),
     scored AS (
       SELECT
         p.id,
-        MAX(c.source_score)
+        (
+          MAX(c.source_score)
           + LEAST(25.0, LN(1 + p."likesCount") * 6)
           + LEAST(18.0, LN(1 + p."repostsCount") * 7)
           + LEAST(16.0, LN(1 + p."commentsCount") * 5)
-          + GREATEST(
-              0.0,
-              20.0 - (EXTRACT(EPOCH FROM (now() - p."createdAt")) / 3600.0)
-            ) AS score
+          + LEAST(20.0, p.id::double precision * 0.001)
+        )::double precision AS score
       FROM candidates c
       JOIN "Post" p ON p.id = c.id
       GROUP BY p.id
     )
-    SELECT id
+    SELECT id, score
     FROM scored
+    ${rankedCursorFilter}
     ORDER BY score DESC, id DESC
     LIMIT ${limit}
   `;
 
-  return rows.map((row) => row.id);
+  return { rows };
 }
 
 // Turn a set of post ids into full posts (newest-first), dropping any deleted

--- a/server/src/controllers/postControllers/getPostController.ts
+++ b/server/src/controllers/postControllers/getPostController.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 
+import { Prisma } from '../../../generated/prisma/client';
 import { prisma } from '../../db';
 import {
   CELEBRITY_FOLLOWER_THRESHOLD,
@@ -92,38 +93,10 @@ export async function getForYouPosts(req: Request, res: Response) {
 
     const { cursor, limit } = input.data;
 
-    // 1. In-Network: Get followed users
-    const followedUsers = await prisma.userFollows.findMany({
-      where: { followerId: currentUserId },
-      select: { followingId: true },
-    });
-    const followedIds = followedUsers.map((f) => f.followingId);
+    const candidateIds = await rankedForYouPostIds(currentUserId, cursor, limit);
 
-    // 2. Extended Network: Posts liked by the people you follow
-    const likedByFollowed = await prisma.like.findMany({
-      where: { userId: { in: followedIds } },
-      select: { postId: true },
-    });
-    const likedPostIdsByFollowed = likedByFollowed.map((l) => l.postId);
-
-    // 3. Blended Fetch
     const posts = await prisma.post.findMany({
-      where: {
-        OR: [
-          { postedById: { in: followedIds } }, // In-Network
-          { id: { in: likedPostIdsByFollowed } }, // Extended Network
-          { likesCount: { gte: 5 } }, // Out-of-Network (Popular fallback)
-        ],
-        isDeleted: false,
-      },
-      orderBy: [
-        { createdAt: 'desc' },
-        { likesCount: 'desc' },
-        { commentsCount: 'desc' },
-      ],
-      take: limit,
-      cursor: cursor ? { id: cursor } : undefined,
-      skip: cursor ? 1 : 0,
+      where: { id: { in: candidateIds }, isDeleted: false },
       include: {
         postedBy: {
           select: {
@@ -148,6 +121,8 @@ export async function getForYouPosts(req: Request, res: Response) {
         },
       },
     });
+    const order = new Map(candidateIds.map((id, index) => [id, index]));
+    posts.sort((a, b) => (order.get(a.id) ?? 0) - (order.get(b.id) ?? 0));
 
     const reposted = await getRepostedSet(
       currentUserId,
@@ -167,6 +142,139 @@ export async function getForYouPosts(req: Request, res: Response) {
     res.status(500).json({ message: 'Unknown error occurred!' });
     console.error('Error in get for you posts:', error);
   }
+}
+
+type RankedPostRow = {
+  id: number;
+};
+
+async function rankedForYouPostIds(
+  currentUserId: number,
+  cursor: number | undefined,
+  limit: number,
+): Promise<number[]> {
+  const cursorFilter = cursor
+    ? Prisma.sql`AND p.id < ${cursor}`
+    : Prisma.empty;
+
+  const rows = await prisma.$queryRaw<RankedPostRow[]>`
+    WITH followed AS (
+      SELECT "followingId" AS user_id
+      FROM "UserFollows"
+      WHERE "followerId" = ${currentUserId}
+    ),
+    affinity_authors AS (
+      SELECT DISTINCT source_posts."postedById" AS user_id
+      FROM "Like" l
+      JOIN "Post" source_posts ON source_posts.id = l."postId"
+      WHERE l."userId" = ${currentUserId}
+
+      UNION
+
+      SELECT DISTINCT source_posts."postedById" AS user_id
+      FROM "Repost" r
+      JOIN "Post" source_posts ON source_posts.id = r."postId"
+      WHERE r."userId" = ${currentUserId}
+
+      UNION
+
+      SELECT DISTINCT parent_posts."postedById" AS user_id
+      FROM "Post" comments
+      JOIN "Post" parent_posts ON parent_posts.id = comments."parentPostId"
+      WHERE comments."postedById" = ${currentUserId}
+    ),
+    candidates AS (
+      SELECT p.id, 75.0 AS source_score
+      FROM "Post" p
+      WHERE p."postedById" = ${currentUserId}
+        AND p."parentPostId" IS NULL
+        AND p."isDeleted" = false
+        ${cursorFilter}
+
+      UNION ALL
+
+      SELECT p.id, 70.0 AS source_score
+      FROM "Post" p
+      JOIN followed f ON f.user_id = p."postedById"
+      WHERE p."parentPostId" IS NULL
+        AND p."isDeleted" = false
+        ${cursorFilter}
+
+      UNION ALL
+
+      SELECT p.id, 50.0 AS source_score
+      FROM "Post" p
+      JOIN "Repost" r ON r."postId" = p.id
+      JOIN followed f ON f.user_id = r."userId"
+      WHERE p."parentPostId" IS NULL
+        AND p."isDeleted" = false
+        ${cursorFilter}
+
+      UNION ALL
+
+      SELECT p.id, 45.0 AS source_score
+      FROM "Post" p
+      JOIN "Like" l ON l."postId" = p.id
+      JOIN followed f ON f.user_id = l."userId"
+      WHERE p."parentPostId" IS NULL
+        AND p."isDeleted" = false
+        ${cursorFilter}
+
+      UNION ALL
+
+      SELECT p.id, 35.0 AS source_score
+      FROM "Post" p
+      JOIN affinity_authors a ON a.user_id = p."postedById"
+      WHERE p."postedById" <> ${currentUserId}
+        AND p."parentPostId" IS NULL
+        AND p."isDeleted" = false
+        ${cursorFilter}
+
+      UNION ALL
+
+      SELECT p.id, 25.0 AS source_score
+      FROM "Post" p
+      WHERE p."parentPostId" IS NULL
+        AND p."isDeleted" = false
+        AND (
+          p."likesCount" >= 5
+          OR p."repostsCount" >= 2
+          OR p."commentsCount" >= 3
+        )
+        ${cursorFilter}
+
+      UNION ALL
+
+      SELECT p.id, 15.0 AS source_score
+      FROM "Post" p
+      WHERE p."parentPostId" IS NULL
+        AND p."isDeleted" = false
+        ${cursorFilter}
+      ORDER BY id DESC
+      LIMIT ${limit * 8}
+    ),
+    scored AS (
+      SELECT
+        p.id,
+        MAX(c.source_score)
+          + LEAST(25.0, LN(1 + p."likesCount") * 6)
+          + LEAST(18.0, LN(1 + p."repostsCount") * 7)
+          + LEAST(16.0, LN(1 + p."commentsCount") * 5)
+          + GREATEST(
+              0.0,
+              20.0 - (EXTRACT(EPOCH FROM (now() - p."createdAt")) / 3600.0)
+            ) AS score
+      FROM candidates c
+      JOIN "Post" p ON p.id = c.id
+      GROUP BY p.id
+    )
+    SELECT id
+    FROM scored
+    ORDER BY score DESC, id DESC
+    LIMIT ${limit}
+  `;
+
+  return rows.map((row) => row.id);
 }
 
 // Turn a set of post ids into full posts (newest-first), dropping any deleted

--- a/server/src/types/validation/schemas.ts
+++ b/server/src/types/validation/schemas.ts
@@ -6,6 +6,11 @@ export const PostQuerySchema = z.object({
   limit: z.coerce.number().int().positive().default(10),
 });
 
+export const ForYouPostQuerySchema = z.object({
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().positive().default(10),
+});
+
 export const SearchQuerySchema = z.object({
   q: z.string().min(1),
   cursor: z.coerce.number().int().positive().optional(),

--- a/server/test/forYou.test.ts
+++ b/server/test/forYou.test.ts
@@ -1,0 +1,97 @@
+import request from 'supertest';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { app } from '../src/app';
+import { prisma } from '../src/db';
+import { createPost, secondUser, signup } from './helpers';
+import { resetDatabase } from './setup/resetDb';
+
+function bearer(token: string) {
+  return `Bearer ${token}`;
+}
+
+function forYou(token: string) {
+  return request(app)
+    .get('/api/v1/posts/for-you?limit=10')
+    .set('Authorization', bearer(token));
+}
+
+describe('for-you ranking', () => {
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  it('serves recent public posts to a new user with no follows', async () => {
+    const alice = (await signup()).body;
+    const bob = (await signup(secondUser)).body;
+
+    const bobPostId = (await createPost(bob.accessToken, { text: 'from bob' }))
+      .body.post.id;
+
+    const res = await forYou(alice.accessToken);
+
+    expect(res.status).toBe(200);
+    expect(res.body.posts.map((post: { id: number }) => post.id)).toContain(
+      bobPostId,
+    );
+  });
+
+  it('includes posts liked by people the viewer follows', async () => {
+    const alice = (await signup()).body;
+    const bob = (await signup(secondUser)).body;
+    const carol = (
+      await signup({
+        username: 'carol',
+        email: 'carol@example.com',
+        name: 'Carol',
+      })
+    ).body;
+
+    await request(app)
+      .put(`/api/v1/users/follow/${bob.userId}`)
+      .set('Authorization', bearer(alice.accessToken))
+      .expect(204);
+
+    const carolPostId = (
+      await createPost(carol.accessToken, { text: 'liked by followed user' })
+    ).body.post.id;
+
+    await request(app)
+      .put(`/api/v1/posts/${carolPostId}/like`)
+      .set('Authorization', bearer(bob.accessToken))
+      .expect(204);
+
+    const res = await forYou(alice.accessToken);
+
+    expect(res.status).toBe(200);
+    expect(res.body.posts.map((post: { id: number }) => post.id)).toContain(
+      carolPostId,
+    );
+  });
+
+  it('excludes comments from the candidate pool', async () => {
+    const alice = (await signup()).body;
+    const bob = (await signup(secondUser)).body;
+
+    const parentPostId = (await createPost(bob.accessToken, { text: 'parent' }))
+      .body.post.id;
+    const commentId = (
+      await request(app)
+        .post(`/api/v1/posts/${parentPostId}`)
+        .set('Authorization', bearer(bob.accessToken))
+        .send({ text: 'popular comment' })
+    ).body.post.id;
+
+    await prisma.post.update({
+      where: { id: commentId },
+      data: { likesCount: 100, commentsCount: 100, repostsCount: 100 },
+    });
+
+    const res = await forYou(alice.accessToken);
+
+    expect(res.status).toBe(200);
+    expect(res.body.posts.map((post: { id: number }) => post.id)).not.toContain(
+      commentId,
+    );
+  });
+});

--- a/server/test/forYou.test.ts
+++ b/server/test/forYou.test.ts
@@ -16,6 +16,13 @@ function forYou(token: string) {
     .set('Authorization', bearer(token));
 }
 
+function forYouPage(token: string, limit: number, cursor?: string) {
+  return request(app)
+    .get('/api/v1/posts/for-you')
+    .query({ limit, cursor })
+    .set('Authorization', bearer(token));
+}
+
 describe('for-you ranking', () => {
   beforeEach(async () => {
     await resetDatabase();
@@ -93,5 +100,34 @@ describe('for-you ranking', () => {
     expect(res.body.posts.map((post: { id: number }) => post.id)).not.toContain(
       commentId,
     );
+  });
+
+  it('paginates by ranking cursor without duplicating posts', async () => {
+    const alice = (await signup()).body;
+    const bob = (await signup(secondUser)).body;
+
+    for (let i = 0; i < 6; i += 1) {
+      await createPost(bob.accessToken, { text: `ranked post ${i}` });
+    }
+
+    const firstPage = await forYouPage(alice.accessToken, 3);
+    expect(firstPage.status).toBe(200);
+    expect(firstPage.body.posts).toHaveLength(3);
+    expect(typeof firstPage.body.nextCursor).toBe('string');
+
+    const secondPage = await forYouPage(
+      alice.accessToken,
+      3,
+      firstPage.body.nextCursor as string,
+    );
+    expect(secondPage.status).toBe(200);
+    expect(secondPage.body.posts).toHaveLength(3);
+
+    const firstIds = firstPage.body.posts.map((post: { id: number }) => post.id);
+    const secondIds = secondPage.body.posts.map(
+      (post: { id: number }) => post.id,
+    );
+
+    expect(new Set([...firstIds, ...secondIds]).size).toBe(6);
   });
 });

--- a/server/test/forYou.test.ts
+++ b/server/test/forYou.test.ts
@@ -23,6 +23,10 @@ function forYouPage(token: string, limit: number, cursor?: string) {
     .set('Authorization', bearer(token));
 }
 
+function postIds(res: request.Response): number[] {
+  return res.body.posts.map((post: { id: number }) => post.id);
+}
+
 describe('for-you ranking', () => {
   beforeEach(async () => {
     await resetDatabase();
@@ -38,9 +42,7 @@ describe('for-you ranking', () => {
     const res = await forYou(alice.accessToken);
 
     expect(res.status).toBe(200);
-    expect(res.body.posts.map((post: { id: number }) => post.id)).toContain(
-      bobPostId,
-    );
+    expect(postIds(res)).toContain(bobPostId);
   });
 
   it('includes posts liked by people the viewer follows', async () => {
@@ -71,9 +73,7 @@ describe('for-you ranking', () => {
     const res = await forYou(alice.accessToken);
 
     expect(res.status).toBe(200);
-    expect(res.body.posts.map((post: { id: number }) => post.id)).toContain(
-      carolPostId,
-    );
+    expect(postIds(res)).toContain(carolPostId);
   });
 
   it('excludes comments from the candidate pool', async () => {
@@ -97,8 +97,114 @@ describe('for-you ranking', () => {
     const res = await forYou(alice.accessToken);
 
     expect(res.status).toBe(200);
-    expect(res.body.posts.map((post: { id: number }) => post.id)).not.toContain(
-      commentId,
+    expect(postIds(res)).not.toContain(commentId);
+  });
+
+  it('ranks followed-author posts above ordinary recent posts', async () => {
+    const alice = (await signup()).body;
+    const bob = (await signup(secondUser)).body;
+    const carol = (
+      await signup({
+        username: 'carol',
+        email: 'carol@example.com',
+        name: 'Carol',
+      })
+    ).body;
+
+    const followedPostId = (
+      await createPost(bob.accessToken, { text: 'followed author' })
+    ).body.post.id;
+    const ordinaryPostId = (
+      await createPost(carol.accessToken, { text: 'ordinary recent' })
+    ).body.post.id;
+
+    await request(app)
+      .put(`/api/v1/users/follow/${bob.userId}`)
+      .set('Authorization', bearer(alice.accessToken))
+      .expect(204);
+
+    const res = await forYou(alice.accessToken);
+
+    expect(res.status).toBe(200);
+    const ids = postIds(res);
+    expect(ids.indexOf(followedPostId)).toBeLessThan(
+      ids.indexOf(ordinaryPostId),
+    );
+  });
+
+  it('ranks high-engagement posts above ordinary recent posts for cold start', async () => {
+    const alice = (await signup()).body;
+    const bob = (await signup(secondUser)).body;
+    const carol = (
+      await signup({
+        username: 'carol',
+        email: 'carol@example.com',
+        name: 'Carol',
+      })
+    ).body;
+
+    const popularPostId = (
+      await createPost(bob.accessToken, { text: 'popular post' })
+    ).body.post.id;
+    const ordinaryPostId = (
+      await createPost(carol.accessToken, { text: 'ordinary recent' })
+    ).body.post.id;
+
+    await prisma.post.update({
+      where: { id: popularPostId },
+      data: { likesCount: 12, commentsCount: 4, repostsCount: 3 },
+    });
+
+    const res = await forYou(alice.accessToken);
+
+    expect(res.status).toBe(200);
+    const ids = postIds(res);
+    expect(ids.indexOf(popularPostId)).toBeLessThan(
+      ids.indexOf(ordinaryPostId),
+    );
+  });
+
+  it('ranks posts liked by followed users above ordinary recent posts', async () => {
+    const alice = (await signup()).body;
+    const bob = (await signup(secondUser)).body;
+    const carol = (
+      await signup({
+        username: 'carol',
+        email: 'carol@example.com',
+        name: 'Carol',
+      })
+    ).body;
+    const dave = (
+      await signup({
+        username: 'dave',
+        email: 'dave@example.com',
+        name: 'Dave',
+      })
+    ).body;
+
+    await request(app)
+      .put(`/api/v1/users/follow/${bob.userId}`)
+      .set('Authorization', bearer(alice.accessToken))
+      .expect(204);
+
+    const socialProofPostId = (
+      await createPost(carol.accessToken, { text: 'liked by bob' })
+    ).body.post.id;
+    const ordinaryPostId = (
+      await createPost(dave.accessToken, { text: 'ordinary recent' })
+    ).body.post.id;
+
+    await request(app)
+      .put(`/api/v1/posts/${socialProofPostId}/like`)
+      .set('Authorization', bearer(bob.accessToken))
+      .expect(204);
+
+    const res = await forYou(alice.accessToken);
+
+    expect(res.status).toBe(200);
+    const ids = postIds(res);
+    expect(ids.indexOf(socialProofPostId)).toBeLessThan(
+      ids.indexOf(ordinaryPostId),
     );
   });
 
@@ -123,10 +229,8 @@ describe('for-you ranking', () => {
     expect(secondPage.status).toBe(200);
     expect(secondPage.body.posts).toHaveLength(3);
 
-    const firstIds = firstPage.body.posts.map((post: { id: number }) => post.id);
-    const secondIds = secondPage.body.posts.map(
-      (post: { id: number }) => post.id,
-    );
+    const firstIds = postIds(firstPage);
+    const secondIds = postIds(secondPage);
 
     expect(new Set([...firstIds, ...secondIds]).size).toBe(6);
   });


### PR DESCRIPTION
## Summary

Replaces the previous For You feed logic with a lightweight recommendation pipeline based on candidate generation and score-based ranking.

## Changes

- Generates For You candidates from multiple sources:
  - viewer’s own posts
  - followed authors
  - posts liked or reposted by followed users
  - authors the viewer has interacted with before
  - high-engagement posts
  - recent public posts for cold start
- Ranks candidates using source strength, engagement, affinity, and freshness signals.
- Excludes comments from the For You candidate pool.
- Adds an opaque score cursor so pagination follows ranking order without duplicate posts.
- Keeps the visible For You feed stable after following/unfollowing users, avoiding an immediate reshuffle while the user is scrolling.
- Adds integration tests for cold start, social proof candidates, comment exclusion, ranking priorities, and cursor pagination.
- Updates README documentation for the recommendation logic.

## Verification

- `npx --yes pnpm@10.34.1 --filter server exec tsc --noEmit`
- `npx --yes pnpm@10.34.1 --filter client exec tsc -b`
- `npx --yes pnpm@10.34.1 exec vitest run test/forYou.test.ts`
- `npx --yes pnpm@10.34.1 --filter server lint`
- `npx --yes pnpm@10.34.1 --filter server build`
- `npx --yes pnpm@10.34.1 --filter client build`
- `npx --yes pnpm@10.34.1 --filter server test`