### PR TITLE
fix: restore feed scroll position

### DIFF
--- a/client/src/features/posts/components/PostItem/PostItem.tsx
+++ b/client/src/features/posts/components/PostItem/PostItem.tsx
@@ -1,5 +1,6 @@
 import { useLocation, useNavigate } from 'react-router-dom';
 
+import { saveFeedScrollSnapshot } from '@/utils/feedScrollMemory.ts';
 import { convertPostTime } from '@/utils/convertPostTime.ts';
 import { Divider, Flex, Text } from '@mantine/core';
 import { IconRepeat } from '@tabler/icons-react';
@@ -18,6 +19,7 @@ type PostProps = {
   hideDivider?: boolean;
   clickTarget?: string | null;
   replaceOnClick?: boolean;
+  feedScrollKey?: string | null;
 };
 
 export function PostItem({
@@ -26,6 +28,7 @@ export function PostItem({
   hideDivider,
   clickTarget,
   replaceOnClick,
+  feedScrollKey,
 }: PostProps) {
   const navigate = useNavigate();
   const location = useLocation();
@@ -33,6 +36,16 @@ export function PostItem({
 
   const openPost = () => {
     if (!postPath || location.pathname === postPath) return;
+    const postElement = document.querySelector<HTMLElement>(
+      `[data-post-id="${post.id}"]`,
+    );
+
+    saveFeedScrollSnapshot(
+      feedScrollKey ?? null,
+      post.id,
+      postElement?.getBoundingClientRect().top ?? 0,
+    );
+
     void navigate(postPath, { replace: replaceOnClick });
   };
 
@@ -41,6 +54,7 @@ export function PostItem({
       <div
         onClick={openPost}
         className={classes.postItem}
+        data-post-id={post.id}
         data-clickable={postPath ? true : undefined}
       >
         {post.repostedBy && (

--- a/client/src/features/posts/components/PostList/PostList.tsx
+++ b/client/src/features/posts/components/PostList/PostList.tsx
@@ -1,7 +1,12 @@
 import { useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
+import { useLocation, useNavigationType } from 'react-router-dom';
 
 import { Loading } from '@/components/Loading/Loading.tsx';
+import {
+  getFeedScrollKey,
+  restoreFeedScrollSnapshot,
+} from '@/utils/feedScrollMemory.ts';
 import { Center, Loader, Stack } from '@mantine/core';
 
 import { usePostsList } from '../../hooks/usePostList.ts';
@@ -15,12 +20,35 @@ export function PostList({ endpoint }: PostListProps) {
   const { data, isPending, isError, hasNextPage, fetchNextPage } =
     usePostsList(endpoint);
   const { ref, inView } = useInView();
+  const location = useLocation();
+  const navigationType = useNavigationType();
+  const feedScrollKey = getFeedScrollKey(
+    location.pathname,
+    endpoint ?? location.pathname,
+  );
 
   useEffect(() => {
     if (inView && hasNextPage) {
       void fetchNextPage();
     }
   }, [inView, hasNextPage, fetchNextPage]);
+
+  useEffect(() => {
+    if (isPending) return;
+
+    const frame = requestAnimationFrame(() => {
+      if (navigationType === 'POP') {
+        restoreFeedScrollSnapshot(feedScrollKey);
+        return;
+      }
+
+      if (feedScrollKey) {
+        window.scrollTo({ top: 0, behavior: 'auto' });
+      }
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, [feedScrollKey, isPending, navigationType]);
 
   if (isPending) {
     return <Loading />;
@@ -37,6 +65,7 @@ export function PostList({ endpoint }: PostListProps) {
           <PostItem
             post={post}
             key={post.id}
+            feedScrollKey={feedScrollKey}
           />
         )),
       )}

--- a/client/src/features/posts/hooks/usePostList.ts
+++ b/client/src/features/posts/hooks/usePostList.ts
@@ -62,6 +62,7 @@ export function usePostsList(endpoint = location.pathname) {
       },
       initialPageParam: 0,
       getNextPageParam: (lastPage) => lastPage.nextCursor,
+      staleTime: 1000 * 60,
     });
 
   return {

--- a/client/src/utils/feedScrollMemory.ts
+++ b/client/src/utils/feedScrollMemory.ts
@@ -1,0 +1,52 @@
+const feedPaths = new Set(['/', '/for-you', '/following']);
+
+type FeedScrollSnapshot = {
+  postId: number;
+  scrollY: number;
+  anchorTop: number;
+};
+
+const snapshots = new Map<string, FeedScrollSnapshot>();
+
+export function getFeedScrollKey(pathname: string, endpoint: string) {
+  if (!feedPaths.has(pathname)) return null;
+  return endpoint;
+}
+
+export function saveFeedScrollSnapshot(
+  key: string | null,
+  postId: number,
+  anchorTop: number,
+) {
+  if (!key) return;
+
+  snapshots.set(key, {
+    postId,
+    scrollY: window.scrollY,
+    anchorTop,
+  });
+}
+
+export function restoreFeedScrollSnapshot(key: string | null) {
+  if (!key) return false;
+
+  const snapshot = snapshots.get(key);
+  if (!snapshot) return false;
+
+  const postElement = document.querySelector<HTMLElement>(
+    `[data-post-id="${snapshot.postId}"]`,
+  );
+
+  if (!postElement) {
+    window.scrollTo({ top: snapshot.scrollY, behavior: 'auto' });
+    return true;
+  }
+
+  const postTop = postElement.getBoundingClientRect().top;
+  window.scrollTo({
+    top: window.scrollY + postTop - snapshot.anchorTop,
+    behavior: 'auto',
+  });
+
+  return true;
+}


### PR DESCRIPTION
**Summary**

Fixes two feed navigation bugs:

- Returning from a post page now restores the feed near the original clicked post instead of jumping to a different place.
- Switching between For You and Following now starts each feed at the top instead of reusing the previous feed’s scroll position.
- Adds lightweight client-side feed scroll memory keyed by feed route.
- Keeps feed query data fresh briefly so the list does not immediately rebuild during back navigation.

**Tests**

- `npx --yes pnpm@10.34.1 --filter client build`
